### PR TITLE
보안 취약점 5종 수정 (IDOR/접근제어/반사형 XSS)

### DIFF
--- a/src/main/java/foodcart/FoodCartDao.java
+++ b/src/main/java/foodcart/FoodCartDao.java
@@ -111,14 +111,15 @@ public class FoodCartDao {
 		return list;
 	}
 	
-	//유지))카트 개별 삭제
-	public void deleteCart(String cart_idx) {
+	//유지))카트 개별 삭제(소유자 범위로 제한해 IDOR 방지)
+	public void deleteCart(String cart_idx, String m_num) {
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
-		String sql="delete from foodcart where cart_idx=?";
+		String sql="delete from foodcart where cart_idx=? and m_num=?";
 		try {
 			pstmt=conn.prepareStatement(sql);
 			pstmt.setString(1, cart_idx);
+			pstmt.setString(2, m_num);
 			pstmt.execute();
 		} catch (SQLException e) {
 			// TODO Auto-generated catch block

--- a/src/main/webapp/foodcourt/foodcartdelete.jsp
+++ b/src/main/webapp/foodcourt/foodcartdelete.jsp
@@ -7,6 +7,8 @@ if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
 String cart_idx=request.getParameter("cart_idx");
+// 소유자는 클라이언트 입력을 신뢰하지 않고 세션 사용자로부터 서버에서 도출(IDOR 방지)
+String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
 FoodCartDao dao=new FoodCartDao();
-dao.deleteCart(cart_idx);
+dao.deleteCart(cart_idx, m_num);
 %>

--- a/src/main/webapp/hugesoinfo/checkfavorite.jsp
+++ b/src/main/webapp/hugesoinfo/checkfavorite.jsp
@@ -5,13 +5,16 @@
 
 <!-- 유지 작성함  -->
 <%
-String m_num=request.getParameter("m_num");
+// 로그인 필수 + 조회 대상은 세션 사용자로 강제(타인 즐겨찾기 노출 방지)
+if(!util.SecurityUtil.isLogin(session)){
+	response.sendError(403); return;
+}
+MemInfoDao dao=new MemInfoDao();
+String m_num=dao.getM_num(util.SecurityUtil.currentId(session));
 String h_num=request.getParameter("h_num");
 
-MemInfoDao dao=new MemInfoDao();
 int fav=dao.isFavorite(m_num, h_num);
 JSONObject ob=new JSONObject();
 ob.put("fav", fav);
 out.print(ob.toString());
 %>
-<%=ob.toString()%>

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -282,7 +282,7 @@ if(list2.isEmpty()){
   if(startPage>1)
   {%>
 	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=startPage-1%>&h_name=<%=h_name %>" style="color: black;">이전</a>
+	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=startPage-1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>" style="color: black;">이전</a>
 	  </li>
   <%}
     for(int pp=startPage;pp<=endPage;pp++)
@@ -290,12 +290,12 @@ if(list2.isEmpty()){
     	if(pp==currentPage)
     	{%>
     		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=pp%>&h_name=<%=h_name %>"><%=pp %></a>
+    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
     		</li>
     	<%}else
     	{%>
     		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=pp%>&h_name=<%=h_name %>"><%=pp %></a>
+    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
     		</li>
     	<%}
     }
@@ -304,7 +304,7 @@ if(list2.isEmpty()){
     if(endPage<totalPage)
     {%>
     	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=endPage+1%>&h_name=<%=h_name %>"
+    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=endPage+1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"
     		style="color: black;">다음</a>
     	</li>
     <%}

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -423,7 +423,7 @@ if(list2.isEmpty()){
   if(startPage>1)
   {%>
 	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=startPage-1%>&h_name=<%=h_name %>" style="color: black;">이전</a>
+	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=startPage-1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>" style="color: black;">이전</a>
 	  </li>
   <%}
     for(int pp=startPage;pp<=endPage;pp++)
@@ -431,12 +431,12 @@ if(list2.isEmpty()){
     	if(pp==currentPage)
     	{%>
     		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=pp%>&h_name=<%=h_name %>"><%=pp %></a>
+    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
     		</li>
     	<%}else
     	{%>
     		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=pp%>&h_name=<%=h_name %>"><%=pp %></a>
+    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
     		</li>
     	<%}
     }
@@ -445,7 +445,7 @@ if(list2.isEmpty()){
     if(endPage<totalPage)
     {%>
     	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=endPage+1%>&h_name=<%=h_name %>"
+    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=endPage+1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"
     		style="color: black;">다음</a>
     	</li>
     <%}

--- a/src/main/webapp/mypage/updateaction.jsp
+++ b/src/main/webapp/mypage/updateaction.jsp
@@ -24,7 +24,7 @@
 		return;
 	}
 
-	String m_num=request.getParameter("m_num");
+	// m_num은 클라이언트 입력을 신뢰하지 않고 세션 사용자로부터 서버에서 도출(IDOR 방지)
 	String m_pass=request.getParameter("m_pass");   // 현재 비밀번호(평문)
 	String m_upass=request.getParameter("m_upass");  // 새 비밀번호(평문, 비어있으면 변경 안 함)
 	String m_name=request.getParameter("m_name");
@@ -59,7 +59,7 @@
 	}
 
 	MemInfoDto dto=new MemInfoDto();
-	dto.setM_num(m_num);
+	dto.setM_num(current.getM_num());
 	dto.setM_pass(finalPass);
 	dto.setM_name(m_name);
 	dto.setM_nick(m_nick);

--- a/src/main/webapp/qaboard/qaAction.jsp
+++ b/src/main/webapp/qaboard/qaAction.jsp
@@ -2,6 +2,13 @@
 <%@page import="qa.model.QaDto"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
+<%
+  // 로그인 필수: 비로그인 사용자의 Q&A 작성(및 myid=null INSERT) 차단
+  if(!util.SecurityUtil.isLogin(session)){
+    response.sendRedirect("../index.jsp?main=member/loginform.jsp");
+    return;
+  }
+%>
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
## 개요

3차 시큐어 코드 리뷰에서 **코드로 직접 확인된** 취약점 5종을 수정한다. 기존 보안 헬퍼(`SecurityUtil.isLogin/currentId/urlEncode`, `MemInfoDao.getM_num`)가 있음에도 일부 액션 페이지에 가드가 누락된 경로를 보완했다.

## 수정 내용

| 심각도 | 파일 | 조치 |
|---|---|---|
| Critical | `mypage/updateaction.jsp` | 클라이언트 `m_num` 신뢰 제거 → 세션 사용자(`current`)로 강제 도출. 타인 프로필·비밀번호 덮어쓰기(계정 탈취) IDOR 차단 |
| High | `qaboard/qaAction.jsp` | 최상단 `isLogin` 가드 추가(비로그인 작성 및 `myid=null` INSERT 차단) |
| High | `foodcourt/foodcartdelete.jsp`, `foodcart/FoodCartDao.java` | `deleteCart`를 소유자 범위(`cart_idx AND m_num`)로 제한, `m_num`은 세션에서 도출(타인 장바구니 삭제 IDOR 차단) |
| Medium | `hugesoinfo/checkfavorite.jsp` | `isLogin` 가드 + `m_num` 세션 도출, JSON 이중 출력 버그 제거 |
| High | `hugesoinfo/hugesolistsearch.jsp`, `hugesolist2search.jsp` | 페이지네이션 `href`의 `h_name` 반사형 XSS를 `SecurityUtil.urlEncode`로 인코딩(중복 페이지 누락 경로 포함) |

## 오탐으로 기각(코드 확인)

- qaDetail 댓글 DOM XSS → `qaListAction.jsp`에서 서버측 `escapeHtml` 적용됨(안전)
- qaDetail `q_num` 반사 → `digitsOnly` 정규화됨
- qaDetail 본문 → `escapeHtml`/`nl2brEscaped` 적용됨
- 업로드/ImageServlet 경로조작 → 검증·이중 정규화 차단 양호

## 검증

- `FoodCartDao.java` `javac -encoding UTF-8` 컴파일 통과
- JSP는 환경상 JspC 불가 → 배포 후 수동 PoC 권장(IDOR 5종 재현 시도 → 차단 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)