### PR TITLE
보안 취약점 6종 수정 (IDOR/반사형XSS/작성자위조/인증오라클)

### DIFF
--- a/src/main/java/grade/model/GradeDao.java
+++ b/src/main/java/grade/model/GradeDao.java
@@ -272,14 +272,35 @@ public class GradeDao {
 		public void deleteGrade(String g_num) {
 			Connection conn=db.getConnection();
 			PreparedStatement pstmt=null;
-			
+
 			String sql="delete from grade where g_num=?";
-			
+
 			try {
 				pstmt=conn.prepareStatement(sql);
-				
+
 				pstmt.setString(1, g_num);
-				
+
+				pstmt.execute();
+			} catch (SQLException e) {
+				e.printStackTrace();
+			} finally {
+				db.dbClose(pstmt, conn);
+			}
+		}
+
+		// 소유자 범위 평점 삭제 (IDOR 방어: 작성자 본인 것만 삭제)
+		public void deleteGrade(String g_num, String g_myid) {
+			Connection conn=db.getConnection();
+			PreparedStatement pstmt=null;
+
+			String sql="delete from grade where g_num=? and g_myid=?";
+
+			try {
+				pstmt=conn.prepareStatement(sql);
+
+				pstmt.setString(1, g_num);
+				pstmt.setString(2, g_myid);
+
 				pstmt.execute();
 			} catch (SQLException e) {
 				e.printStackTrace();

--- a/src/main/java/meminfo/model/MemInfoDao.java
+++ b/src/main/java/meminfo/model/MemInfoDao.java
@@ -622,15 +622,34 @@ public class MemInfoDao {
 		public void favDelete(String f_num) {
 			Connection conn=db.getConnection();
 			PreparedStatement pstmt=null;
-			
+
 			String sql="delete from favorite where f_num=?";
-			
+
 			try {
 				pstmt=conn.prepareStatement(sql);
 				pstmt.setString(1, f_num);
 				pstmt.execute();
 			} catch (SQLException e) {
 				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}finally {
+				db.dbClose(pstmt, conn);
+			}
+		}
+
+		// 소유자 범위 즐겨찾기 삭제 (IDOR 방어: 세션 m_num 소유분만 삭제)
+		public void favDelete(String f_num, String m_num) {
+			Connection conn=db.getConnection();
+			PreparedStatement pstmt=null;
+
+			String sql="delete from favorite where f_num=? and m_num=?";
+
+			try {
+				pstmt=conn.prepareStatement(sql);
+				pstmt.setString(1, f_num);
+				pstmt.setString(2, m_num);
+				pstmt.execute();
+			} catch (SQLException e) {
 				e.printStackTrace();
 			}finally {
 				db.dbClose(pstmt, conn);

--- a/src/main/webapp/eventboard/eventUpdateForm.jsp
+++ b/src/main/webapp/eventboard/eventUpdateForm.jsp
@@ -48,8 +48,8 @@
   <%
 
    //num,currentPage
-   String e_num = request.getParameter("e_num");
-   String currentPage = request.getParameter("currentPage");
+   String e_num = util.SecurityUtil.digitsOnly(request.getParameter("e_num"));
+   String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    EventDao dao = new EventDao();
    EventDto dto = dao.getDataEvent(e_num);
@@ -62,8 +62,8 @@
   <!-- 저장폼  -->
    <div style="margin: 100px 200px; width: 800px; margin-left: 28%;">
      <form action="eventboard/eventUpdateAction.jsp" method="post" enctype="multipart/form-data">
-      <input type="hidden" name=e_num  value="<%=e_num%>">
-      <input type="hidden" name="currentPage" value="<%=currentPage%>">
+      <input type="hidden" name="e_num"  value="<%=util.SecurityUtil.escapeHtml(e_num)%>">
+      <input type="hidden" name="currentPage" value="<%=util.SecurityUtil.escapeHtml(currentPage)%>">
        <table class="table">
          <caption align="top"><h5><b>이벤트 수정</b></h5></caption>
            <tr>

--- a/src/main/webapp/foodgrade/insertfoodgrade.jsp
+++ b/src/main/webapp/foodgrade/insertfoodgrade.jsp
@@ -12,6 +12,8 @@
 <jsp:useBean id="dto" class="foodgrade.model.FoodGradeDto"/>
 <jsp:setProperty property="*" name="dto"/>
 <%
+  // 작성자 위조 방어: 작성자 ID는 클라이언트 값이 아닌 세션 사용자로 강제
+  dto.setFg_myid(util.SecurityUtil.currentId(session));
   dao.insertFoodGrade(dto);
 
 %>	

--- a/src/main/webapp/foodgrade/updatef_grade.jsp
+++ b/src/main/webapp/foodgrade/updatef_grade.jsp
@@ -10,9 +10,9 @@
     if(!util.SecurityUtil.isLogin(session)){
         response.sendError(403); return;
     }
-    String h_num = request.getParameter("h_num");
-    String f_num = request.getParameter("f_num");
-    String fg_foodnum = request.getParameter("f_num");
+    String h_num = util.SecurityUtil.digitsOnly(request.getParameter("h_num"));
+    String f_num = util.SecurityUtil.digitsOnly(request.getParameter("f_num"));
+    String fg_foodnum = f_num;
 
     // 음식 평점을 기반으로 음식 평균 평점 업데이트
     FoodGradeDao fgdao = new FoodGradeDao();

--- a/src/main/webapp/grade/deletegrade.jsp
+++ b/src/main/webapp/grade/deletegrade.jsp
@@ -7,8 +7,13 @@
     if(!util.SecurityUtil.isLogin(session)){
         response.sendError(403); return;
     }
-    String h_num=request.getParameter("h_num");
-	String g_num=request.getParameter("g_num");
+    String h_num=util.SecurityUtil.digitsOnly(request.getParameter("h_num"));
+	String g_num=util.SecurityUtil.digitsOnly(request.getParameter("g_num"));
     GradeDao dao = new GradeDao();
-    dao.deleteGrade(g_num);
+    // IDOR 방어: 관리자는 전체 삭제, 일반 사용자는 본인 작성분만 삭제
+    if(util.SecurityUtil.isAdmin(session)){
+        dao.deleteGrade(g_num);
+    }else{
+        dao.deleteGrade(g_num, util.SecurityUtil.currentId(session));
+    }
 %>

--- a/src/main/webapp/grade/insertgrade.jsp
+++ b/src/main/webapp/grade/insertgrade.jsp
@@ -12,6 +12,8 @@
 <jsp:useBean id="dto" class="grade.model.GradeDto"/>
 <jsp:setProperty property="*" name="dto"/>
 <%
+  // 작성자 위조 방어: 작성자 ID는 클라이언트 값이 아닌 세션 사용자로 강제
+  dto.setG_myid(util.SecurityUtil.currentId(session));
   dao.insertGrade(dto);
 
 %>	

--- a/src/main/webapp/mypage/favdelete.jsp
+++ b/src/main/webapp/mypage/favdelete.jsp
@@ -6,7 +6,9 @@
 if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
-String f_num=request.getParameter("f_num");
+String f_num=util.SecurityUtil.digitsOnly(request.getParameter("f_num"));
 MemInfoDao dao=new MemInfoDao();
-dao.favDelete(f_num);
+// IDOR 방어: m_num을 세션 사용자로부터 도출해 본인 소유분만 삭제
+String m_num=dao.getM_num(util.SecurityUtil.currentId(session));
+dao.favDelete(f_num, m_num);
 %>

--- a/src/main/webapp/mypage/updatepassaction.jsp
+++ b/src/main/webapp/mypage/updatepassaction.jsp
@@ -7,12 +7,17 @@
 <%
 	
 	response.setCharacterEncoding("UTF-8");
-	String m_id=request.getParameter("m_id");
+	// 로그인 필수 (인증 없는 자격증명 확인 오라클 방지)
+	if(!util.SecurityUtil.isLogin(session)){
+		response.sendError(403); return;
+	}
+	// 검증 대상 ID는 클라이언트 입력이 아닌 세션 사용자로 고정 (무차별 대입 방지)
+	String m_id=util.SecurityUtil.currentId(session);
 	String m_pass=request.getParameter("m_pass");
-	
+
 	MemInfoDao dao=new MemInfoDao();
 	MemInfoDto dto=new MemInfoDto();
-	
+
 	boolean idpass=dao.isIdPassMember(m_id, m_pass);
 	
 	//System.out.print(m_id);

--- a/src/main/webapp/noticeboard/noticeUpdateForm.jsp
+++ b/src/main/webapp/noticeboard/noticeUpdateForm.jsp
@@ -48,8 +48,8 @@
   <%
 
    //num,currentPage
-   String n_num = request.getParameter("n_num");
-   String currentPage = request.getParameter("currentPage");
+   String n_num = util.SecurityUtil.digitsOnly(request.getParameter("n_num"));
+   String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    NoticeDao dao = new NoticeDao();
    NoticeDto dto = dao.getDataNotice(n_num);
@@ -62,8 +62,8 @@
   <!-- 저장폼  -->
    <div style="margin: 100px 200px; width: 800px; margin-left: 28%;">
      <form action="noticeboard/noticeUpdateAction.jsp" method="post" enctype="multipart/form-data">
-      <input type="hidden" name=n_num  value="<%=n_num%>">
-      <input type="hidden" name="currentPage" value="<%=currentPage%>">
+      <input type="hidden" name="n_num"  value="<%=util.SecurityUtil.escapeHtml(n_num)%>">
+      <input type="hidden" name="currentPage" value="<%=util.SecurityUtil.escapeHtml(currentPage)%>">
        <table class="table">
          <caption align="top"><h5><b>공지사항 수정</b></h5></caption>
            <tr>

--- a/src/main/webapp/qaboard/qaUpdateForm.jsp
+++ b/src/main/webapp/qaboard/qaUpdateForm.jsp
@@ -16,8 +16,8 @@
   <%
 
    //num,currentPage
-   String q_num = request.getParameter("q_num");
-   String currentPage = request.getParameter("currentPage");
+   String q_num = util.SecurityUtil.digitsOnly(request.getParameter("q_num"));
+   String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    QaDao dao = new QaDao();
    QaDto dto = dao.getDataQa(q_num);
@@ -31,8 +31,8 @@
   <!-- 저장폼  -->
    <div style="margin: 100px 200px; width: 800px; margin-left: 28%;">
      <form action="qaboard/qaUpdateAction.jsp" method="post">
-      <input type="hidden" name="q_num"  value="<%=q_num%>">
-      <input type="hidden" name="currentPage" value="<%=currentPage%>">
+      <input type="hidden" name="q_num"  value="<%=util.SecurityUtil.escapeHtml(q_num)%>">
+      <input type="hidden" name="currentPage" value="<%=util.SecurityUtil.escapeHtml(currentPage)%>">
        <table class="table">
          <caption align="top"><h5><b>문의글 수정</b></h5></caption>
            <tr>

--- a/src/main/webapp/reviewboard/reviewUpdateForm.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateForm.jsp
@@ -54,8 +54,8 @@
     <%
 
    //num,currentPage
-   String r_num = request.getParameter("r_num");
-   String currentPage = request.getParameter("currentPage");
+   String r_num = util.SecurityUtil.digitsOnly(request.getParameter("r_num"));
+   String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    ReviewDao dao = new ReviewDao();
    ReviewDto dto = dao.getDataReview(r_num);
@@ -73,8 +73,8 @@
   <!-- 저장폼  -->
    <div style="margin: 100px 200px; width: 800px; margin-left: 25%;">
      <form action="reviewboard/reviewUpdateAction.jsp" method="post" enctype="multipart/form-data">
-      <input type="hidden" name=r_num  value="<%=r_num%>">
-      <input type="hidden" name="currentPage" value="<%=currentPage%>">
+      <input type="hidden" name="r_num"  value="<%=util.SecurityUtil.escapeHtml(r_num)%>">
+      <input type="hidden" name="currentPage" value="<%=util.SecurityUtil.escapeHtml(currentPage)%>">
        <table class="table">
          <caption align="top"><h5><b>후기 수정</b></h5></caption>
          <td>


### PR DESCRIPTION
## 개요
이전 1~3차 보안 패치는 정상 적용을 코드로 재검증했고, 그 과정에서 **형제/변형 페이지에만 보호가 적용되어 누락된 경로 5건(+Low 1건)** 을 신규 발견·수정했다.

## 수정 내역
| 심각도 | 위치 | 내용 |
|---|---|---|
| **CRITICAL** | `grade/deletegrade.jsp`, `GradeDao` | 평점 삭제 IDOR. `deleteGrade(g_num, g_myid)` 오버로드 추가 → 관리자는 전체 삭제, 일반 사용자는 세션 작성자 소유분만 삭제. `g_num`/`h_num` `digitsOnly` |
| **HIGH** | `mypage/favdelete.jsp`, `MemInfoDao` | 즐겨찾기 삭제 IDOR. `favDelete(f_num, m_num)` 추가 → `m_num`을 세션 ID(`getM_num`)로 도출해 본인 소유분만 삭제 |
| **HIGH** | `noticeUpdateForm`/`eventUpdateForm`/`qaUpdateForm`/`reviewUpdateForm` | 반사형 XSS. 번호·`currentPage` 파라미터 `digitsOnly` 정규화 + `escapeHtml` 출력, `name` 속성 따옴표 보정 |
| **MEDIUM** | `grade/insertgrade.jsp`, `foodgrade/insertfoodgrade.jsp` | 작성자 위조. `setProperty` 직후 작성자 ID(`g_myid`/`fg_myid`)를 세션 사용자로 강제 |
| **MEDIUM** | `mypage/updatepassaction.jsp` | 인증 없는 자격증명 확인 오라클. `isLogin` 가드 + 검증 대상 `m_id`를 세션 사용자로 고정 |
| LOW | `foodgrade/updatef_grade.jsp` | `h_num`/`f_num` `digitsOnly` 정규화 |

기존 패턴 재사용: `FoodCartDao.deleteCart(idx, m_num)`식 소유자 범위 삭제, `updateaction.jsp`의 세션 강제, `SecurityUtil.digitsOnly/escapeHtml/currentId/isAdmin` + `MemInfoDao.getM_num`.

## 검증
- `javac`(Tomcat lib + WEB-INF/lib, `-encoding UTF-8`)로 `src/main/java` 전체 컴파일 **EXIT=0** (신규 DAO 메서드 2종 포함).
- JSP 스크립틀릿이 호출하는 헬퍼/DAO 시그니처를 코드로 전수 대조해 타입 정합 확인.
- JspC 사전컴파일은 이 환경의 standalone JspC 이슈(`Jar.getJarFileURL() ... jar is null` NPE)로 미동작 — 변경 코드와 무관. Tomcat 기동 후 런타임 회귀 테스트 권장(타 계정 삭제 시 0건/403, 폼에 `"><script>` 주입 시 미실행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
