### PR TITLE
보안 취약점 3종 수정 (저장형XSS/평점위변조/raw출력 인코딩)

### DIFF
--- a/src/main/java/util/SecurityUtil.java
+++ b/src/main/java/util/SecurityUtil.java
@@ -147,6 +147,24 @@ public class SecurityUtil {
 	}
 
 	/**
+	 * href 속성에 출력할 외부 링크 URL을 검증한다.
+	 * http/https 절대경로만 허용하고, javascript:/data:/vbscript: 등 위험 스킴은 차단한다.
+	 * 허용 시 HTML 이스케이프한 값을, 미허용/null 시 "#"을 반환한다.
+	 * (관리자 입력 링크라도 스킴 검증으로 XSS·정책 위반을 방지)
+	 */
+	public static String safeUrl(String url) {
+		if (url == null) {
+			return "#";
+		}
+		String trimmed = url.trim();
+		String lower = trimmed.toLowerCase();
+		if (lower.startsWith("http://") || lower.startsWith("https://")) {
+			return escapeHtml(trimmed);
+		}
+		return "#";
+	}
+
+	/**
 	 * URL 쿼리 파라미터용 인코딩(이미지 파일명이 한글 등 비ASCII일 수 있음). null 안전.
 	 */
 	public static String urlEncode(String s) {

--- a/src/main/webapp/foodgrade/foodgradesort.jsp
+++ b/src/main/webapp/foodgrade/foodgradesort.jsp
@@ -34,13 +34,13 @@
         htmlBuilder.append("<div class=\"food-item\" style=\"text-align: center; font-weight: bold; margin-bottom: 20px; margin-right: 20px; cursor: pointer;\" data-fnum=\"")
                    .append(dto.getF_num())
                    .append("\">")
-                   .append("<img alt=\"").append(dto.getF_name()).append("\" src=\"image/food/").append(dto.getF_photo())
+                   .append("<img alt=\"").append(util.SecurityUtil.escapeHtml(dto.getF_name())).append("\" src=\"image/food/").append(dto.getF_photo())
                    .append("\" style=\"width: 220px; height: 200px; margin-bottom: 15px;\" data-fnum=\"").append(dto.getF_num()).append("\"><br>")
                    .append("<div style=\"display: inline-block;\" class=\"starrating\">")
                    .append("<label style=\"-webkit-text-fill-color: gold; font-size: 15px;\">★</label>")
                    .append("<p class=\"avggrade2\" style=\"font-weight: bold; font-size: 15px; display: inline-block;\">").append(dto.getF_grade()).append("</p>")
                    .append("</div>")
-                   .append(dto.getF_name())
+                   .append(util.SecurityUtil.escapeHtml(dto.getF_name()))
                    .append("</div>");
     }
 %>

--- a/src/main/webapp/grade/insertgrade.jsp
+++ b/src/main/webapp/grade/insertgrade.jsp
@@ -12,8 +12,24 @@
 <jsp:useBean id="dto" class="grade.model.GradeDto"/>
 <jsp:setProperty property="*" name="dto"/>
 <%
+  // 저장형 XSS 방어: g_content는 상세페이지 라디오 5종만 허용한다(UI 우회로 임의 문자열 저장 차단).
+  // 이 값은 hugesodetail.jsp의 프로그래스바에 삽입되므로 자유입력을 허용하면 안 된다.
+  java.util.List<String> allowedContent = java.util.Arrays.asList(
+      "시설이 깨끗해요", "휴게시설이 잘 되어 있어요", "음식이 맛있어요", "특별한 메뉴가 있어요", "주차하기 편해요");
+  if(!allowedContent.contains(dto.getG_content())){
+    response.sendError(400); return;
+  }
+  // 숫자 파라미터 정규화(h_num/g_grade)
+  String h_num = util.SecurityUtil.digitsOnly(dto.getH_num());
+  String g_grade = util.SecurityUtil.digitsOnly(dto.getG_grade());
+  if(h_num.isEmpty() || g_grade.isEmpty()){
+    response.sendError(400); return;
+  }
+  dto.setH_num(h_num);
+  dto.setG_grade(g_grade);
+
   // 작성자 위조 방어: 작성자 ID는 클라이언트 값이 아닌 세션 사용자로 강제
   dto.setG_myid(util.SecurityUtil.currentId(session));
   dao.insertGrade(dto);
 
-%>	
+%>

--- a/src/main/webapp/hugesoinfo/contentprogressbar.jsp
+++ b/src/main/webapp/hugesoinfo/contentprogressbar.jsp
@@ -15,7 +15,8 @@
         String[] parts = grade.split(" : ");
         if (parts.length == 2) { // 등급 데이터가 " : "로 올바르게 구분되었는지 확인
             JSONObject entry = new JSONObject();
-            entry.put("label", parts[0]);
+            // 저장형 XSS 방어: g_content는 hugesodetail.jsp에서 innerHTML로 삽입되므로 서버측에서 HTML 이스케이프한다.
+            entry.put("label", util.SecurityUtil.escapeHtml(parts[0]));
             entry.put("value", Integer.parseInt(parts[1]));
             jsonArray.add(entry);
         }

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -780,13 +780,13 @@ function sortFood(sortType) {
 
   
 <!-- 휴게소 이름 출력 -->
-<h2 class="h_name"><%=dto.getH_name()%></h2> 
+<h2 class="h_name"><%=util.SecurityUtil.escapeHtml(dto.getH_name())%></h2> 
 <p class="h_text">
 <% if (gdto.getG_content() != null) { %>
     #<%= util.SecurityUtil.escapeHtml(gdto.getG_content()) %>
 <% }%>&nbsp;
 <% if (ffdto.getF_name() != null) { %>
-    #<%= ffdto.getF_name() %>
+    #<%= util.SecurityUtil.escapeHtml(ffdto.getF_name()) %>
 <% }%>
 </p>
 <div class="avggrade">
@@ -824,7 +824,7 @@ function sortFood(sortType) {
 <li class="op1">
 <div class="tablecell">
 <p class="txt1">주소</p>
-<p class="txt2"><%=dto.getH_addr() %></p>
+<p class="txt2"><%=util.SecurityUtil.escapeHtml(dto.getH_addr()) %></p>
 </div>
 </li>
 <li class="op2">
@@ -836,7 +836,7 @@ function sortFood(sortType) {
 <li class="op3">
 <div class="tablecell">
 <p class="txt1">전화번호</p>
-<p class="txt2"><%=dto.getH_hp() %></p>
+<p class="txt2"><%=util.SecurityUtil.escapeHtml(dto.getH_hp()) %></p>
 </div>
 </li>
 <li class="op4">
@@ -961,7 +961,7 @@ function sortFood(sortType) {
     int count = 0; // 이미지 개수를 세기 위한 변수
     for(FoodDto fdto : foodlist) {
         String f_photo = fdto.getF_photo();
-        String f_name = fdto.getF_name();
+        String f_name = util.SecurityUtil.escapeHtml(fdto.getF_name());
         String f_num = fdto.getF_num();
         String f_grade = fdto.getF_grade();
         count++; // 이미지가 추가될 때마다 개수 증가
@@ -985,7 +985,7 @@ function sortFood(sortType) {
             for (int i = 4; i < foodlist.size(); i++) {
                 FoodDto fdto = foodlist.get(i);
                 String f_photo = fdto.getF_photo();
-                String f_name = fdto.getF_name();
+                String f_name = util.SecurityUtil.escapeHtml(fdto.getF_name());
                 String f_num = fdto.getF_num();
                 String f_grade = fdto.getF_grade();
             %>
@@ -1011,14 +1011,14 @@ function sortFood(sortType) {
         int count1 = 0; // 브랜드 개수를 세기 위한 변수
         for(BrandDto bdto : brandList) {
             String b_photo = bdto.getB_photo();
-            String b_name = bdto.getB_name();
+            String b_name = util.SecurityUtil.escapeHtml(bdto.getB_name());
             String b_addr = bdto.getB_addr();
             count1++; // 브랜드가 추가될 때마다 개수 증가
 
             // 브랜드 출력
         %>
             <div class="brand-item" style="display: <%= count1 <= 4 ? "inline-block" : "none" %>; text-align:center; font-weight:bold; margin-bottom: 20px; margin-right:20px;">
-                <a href="<%=b_addr %>">
+                <a href="<%=util.SecurityUtil.safeUrl(b_addr) %>">
                 <img alt="<%=b_name %>" src="fileview?type=hugeso&name=<%=util.SecurityUtil.urlEncode(b_photo)%>" 
                 style="width: 220px; height:200px;  margin-bottom:15px; cursor:pointer;"></a>
                 <div><%=b_name %></div>
@@ -1031,11 +1031,11 @@ function sortFood(sortType) {
                 for (int i = 4; i < brandList.size(); i++) {
                     BrandDto bdto = brandList.get(i);
                     String b_photo = bdto.getB_photo();
-                    String b_name = bdto.getB_name();
+                    String b_name = util.SecurityUtil.escapeHtml(bdto.getB_name());
                     String b_addr = bdto.getB_addr();
                 %>
                     <div class="brand-item" style="display: none; margin-right:20px;">
-                     <a href="<%=b_addr %>">
+                     <a href="<%=util.SecurityUtil.safeUrl(b_addr) %>">
                         <img alt="<%=b_name %>" src="fileview?type=hugeso&name=<%=util.SecurityUtil.urlEncode(b_photo)%>" 
                         style="width: 220px; height:200px;  margin-bottom:15px; cursor:pointer;" ></a>
                         <div><%=b_name %></div>
@@ -1181,7 +1181,7 @@ toggleContent("hiddenContent1", "moreButton1", "foldButton1", "brand-item", docu
     </div>
     
     
-    <div><span style="font-weight:bold; font-size:20px;"><%=dto.getH_name()%></span>는 이런 점이 좋아요!(1개 선택)</div><br>
+    <div><span style="font-weight:bold; font-size:20px;"><%=util.SecurityUtil.escapeHtml(dto.getH_name())%></span>는 이런 점이 좋아요!(1개 선택)</div><br>
    <div id="g_content" style="display: inline-flex; width:1000px;">
    <div class="form_radio_btn" style="width:200px;">
     <input type="radio" name="g_content" id="clean_facility" value="시설이 깨끗해요" checked>

--- a/src/main/webapp/hugesoinfo/mapaction.jsp
+++ b/src/main/webapp/hugesoinfo/mapaction.jsp
@@ -17,13 +17,14 @@
 		
 		JSONObject ob=new JSONObject();
 		
+		// 클라이언트에서 .html() 등으로 삽입될 수 있어 서버측 HTML 이스케이프(XSS 방지)
 		ob.put("h_num",dto.getH_num());
-		ob.put("h_name", dto.getH_name());
+		ob.put("h_name", util.SecurityUtil.escapeHtml(dto.getH_name()));
 		ob.put("h_xvalue", dto.getH_xvalue());
 		ob.put("h_yvalue", dto.getH_yvalue());
 		ob.put("h_photo", dto.getH_photo());
-		ob.put("h_hp", dto.getH_hp());
-		ob.put("h_addr", dto.getH_addr());
+		ob.put("h_hp", util.SecurityUtil.escapeHtml(dto.getH_hp()));
+		ob.put("h_addr", util.SecurityUtil.escapeHtml(dto.getH_addr()));
 		
 		arr.add(ob);
 	}

--- a/src/main/webapp/hugesoinfo/searchaction.jsp
+++ b/src/main/webapp/hugesoinfo/searchaction.jsp
@@ -18,13 +18,14 @@
 		
 		JSONObject ob=new JSONObject();
 		
+		// 클라이언트에서 .html() 등으로 삽입될 수 있어 서버측 HTML 이스케이프(XSS 방지)
 		ob.put("h_num",dto.getH_num());
-		ob.put("h_name", dto.getH_name());
+		ob.put("h_name", util.SecurityUtil.escapeHtml(dto.getH_name()));
 		ob.put("h_xvalue", dto.getH_xvalue());
 		ob.put("h_yvalue", dto.getH_yvalue());
 		ob.put("h_photo", dto.getH_photo());
-		ob.put("h_hp", dto.getH_hp());
-		ob.put("h_addr", dto.getH_addr());
+		ob.put("h_hp", util.SecurityUtil.escapeHtml(dto.getH_hp()));
+		ob.put("h_addr", util.SecurityUtil.escapeHtml(dto.getH_addr()));
 		
 		arr.add(ob);
 	}

--- a/src/main/webapp/hugesoinfo/updateh_grade.jsp
+++ b/src/main/webapp/hugesoinfo/updateh_grade.jsp
@@ -1,3 +1,4 @@
+<%@page import="grade.model.GradeDao"%>
 <%@page import="hugesoinfo.model.HugesoInfoDao"%>
 <%@page import="hugesoinfo.model.HugesoInfoDto"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
@@ -9,15 +10,22 @@
 	if(!util.SecurityUtil.isLogin(session)){
 		response.sendError(403); return;
 	}
-	String h_num=request.getParameter("h_num");
-	String h_grade=request.getParameter("h_grade");
-	String h_gradecount=request.getParameter("h_gradecount");
+	// 위변조 방어: 클라이언트가 보낸 h_grade/h_gradecount를 신뢰하지 않고
+	// grade 테이블에서 평균/개수를 서버에서 재계산한다(메인 "이달의 휴게소" 랭킹 조작 차단).
+	String h_num=util.SecurityUtil.digitsOnly(request.getParameter("h_num"));
+	if(h_num.isEmpty()){
+		response.sendError(400); return;
+	}
+
+	GradeDao gdao=new GradeDao();
+	String h_grade=gdao.avgGrade(h_num);          // 평균 평점(소수점 1자리), 평점이 없으면 "0.0"
+	int h_gradecount=gdao.getG_myid(h_num).size(); // 평점 개수
 
 	HugesoInfoDto dto=new HugesoInfoDto();
 	dto.setH_num(h_num);
-	dto.setH_grade(h_grade);
-	dto.setH_gradecount(h_gradecount);
-	
+	dto.setH_grade(h_grade==null?"0.0":h_grade);
+	dto.setH_gradecount(String.valueOf(h_gradecount));
+
 	HugesoInfoDao dao = new HugesoInfoDao();
 	dao.updateH_grade(dto);
 

--- a/src/main/webapp/mainlayout/hugesorank.jsp
+++ b/src/main/webapp/mainlayout/hugesorank.jsp
@@ -123,8 +123,8 @@
                 display: inline-block;">
                     <img alt="" src="fileview?type=hugeso&name=<%=util.SecurityUtil.urlEncode(dto.getH_photo())%>" class="h_image">
                     <div class="h_hugeso">
-                        <div class="h_name" style="font-size: 0.85em;"><%=dto.getH_name() %></div>
-                        <div class="h_addr" style="font-size: 0.7em;"><%=dto.getH_addr() %></div>
+                        <div class="h_name" style="font-size: 0.85em;"><%=util.SecurityUtil.escapeHtml(dto.getH_name()) %></div>
+                        <div class="h_addr" style="font-size: 0.7em;"><%=util.SecurityUtil.escapeHtml(dto.getH_addr()) %></div>
                     </div>
                 </a>
             </div>

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -237,7 +237,7 @@
         		    width: 250px; display: block;"><%=util.SecurityUtil.escapeHtml(dto.getN_subject()) %></span></a>
         		    
         		    </td>
-        		    <td align="center"><%=name %></td>
+        		    <td align="center"><%=util.SecurityUtil.escapeHtml(name) %></td>
         		    <td align="center"><%=dto.getN_readcount() %></td>
         		    <td align="center"><%=dto.getN_chu()%></td>
         		    <td align="center"><%=sdf.format(dto.getN_writeday())%></td>

--- a/src/main/webapp/shop/shopList.jsp
+++ b/src/main/webapp/shop/shopList.jsp
@@ -239,7 +239,7 @@ $(function(){
                 <input type="checkbox" value="<%=dto.getS_num()%>" class="alldel1">
                 <% } %>
               <div class="br_total"  style="text-align: center;"> 
-                <a href="<%= dto.getS_site() %>" target="_blank">
+                <a href="<%= util.SecurityUtil.safeUrl(dto.getS_site()) %>" target="_blank">
                   <img src="fileview?type=shop&name=<%= util.SecurityUtil.urlEncode(dto.getS_image()) %>" alt="" class="s_image"><br>
                   <span class="br_name">공식 홈페이지</span>
                 </a>
@@ -288,7 +288,7 @@ $(function(){
                 <input type="checkbox" value="<%=dto.getS_num()%>" class="alldel2">
                 <% } %>
               <div class="br_total">  
-                <a href="<%= dto.getS_site() %>" target="_blank" >
+                <a href="<%= util.SecurityUtil.safeUrl(dto.getS_site()) %>" target="_blank" >
                   <img src="fileview?type=shop&name=<%= util.SecurityUtil.urlEncode(dto.getS_image()) %>" alt="" class="s_image"><br>
                   <span class="br_name">공식 홈페이지</span>
                 </a>
@@ -335,7 +335,7 @@ $(function(){
                 <% }%>
                 
                <div class="br_total"> 
-                <a href="<%= dto.getS_site() %>" target="_blank">
+                <a href="<%= util.SecurityUtil.safeUrl(dto.getS_site()) %>" target="_blank">
                   <img src="fileview?type=shop&name=<%= util.SecurityUtil.urlEncode(dto.getS_image()) %>" alt="" class="s_image"><br>
                   <span class="br_name">공식 홈페이지</span>
                 </a>


### PR DESCRIPTION
## 개요
신규 세션에서 시큐어 코드 리뷰를 코드 기준으로 재수행해 발견한 신규 취약점 3종을 수정했습니다. 1~4차 수정은 실제 적용 상태를 재확인했고(접근제어 가드/IDOR/CSRF 토큰/작성자 위조/BCrypt/업로드 검증/세션), SQL Injection은 발견되지 않았습니다.

## 수정 내역

### 🔴 HIGH — 저장형 XSS 차단
인증된 사용자가 `grade/insertgrade.jsp`에 임의 `g_content`(예: `<img src=x onerror=...>`)를 저장하면, `hugesoinfo/contentprogressbar.jsp`가 escape 없이 JSON으로 내보내고 `hugesodetail.jsp`가 `innerHTML`로 삽입해 모든 방문자(관리자 포함) 브라우저에서 실행되던 경로를 차단.
- `contentprogressbar.jsp`: `label`(g_content) JSON 출력 시 `escapeHtml` 적용
- `insertgrade.jsp`: `g_content`를 허용 문구 5종 화이트리스트로 검증(UI 우회 차단) + `h_num`/`g_grade` `digitsOnly` 정규화

### 🟠 MEDIUM — 평점 집계 위변조 차단
`hugesoinfo/updateh_grade.jsp`가 클라이언트가 보낸 `h_grade`/`h_gradecount`를 그대로 저장해, 임의 휴게소의 평점/랭킹(메인 "이달의 휴게소", `order by h_grade desc`)을 조작할 수 있던 문제 수정.
- 클라이언트 값을 무시하고 `GradeDao.avgGrade()` + `getG_myid().size()`로 서버에서 재계산(형제 페이지 `updatef_grade.jsp`와 동일 패턴) + `h_num` 정규화

### 🟡 LOW — raw `<%= %>` 출력 일괄 인코딩 (CLAUDE.md 정책 일치)
관리자 입력 데이터라 실제 악용성은 낮지만 "raw 출력 금지" 정책을 일관 적용.
- `SecurityUtil.safeUrl` 신설: href에 http/https 스킴만 허용, 위험 스킴은 `#` 폴백
- `hugesodetail.jsp`: h_name/h_addr/h_hp/f_name/b_name → `escapeHtml`, b_addr href → `safeUrl`
- `hugesorank.jsp`(h_name/h_addr), `foodgradesort.jsp`(f_name), `noticeList.jsp`(작성자명) → `escapeHtml`
- `shopList.jsp`: s_site href → `safeUrl`
- `searchaction.jsp`/`mapaction.jsp`: JSON h_name/h_addr/h_hp → `escapeHtml`(소비처가 모두 `.html()`/infowindow HTML 컨텍스트임을 확인, 이중 인코딩 없음)

## 검증
- `javac`로 `src/main/java` 전체 컴파일 성공(EXIT=0) — JSP가 호출하는 신규/기존 헬퍼·DAO 시그니처(`safeUrl`/`escapeHtml`/`digitsOnly`/`avgGrade`/`getG_myid`) 정합 확인

## 남은 후속과제(이번 범위 외)
- 다수 상태변경이 GET + CSRF 토큰 미적용(SameSite=Lax만)
- 빈 껍데기 `myqadeleteaction.jsp`/`myreviewdeleteaction.jsp`(데드코드) 정리
- `printStackTrace` 로거 전환(노출은 error-page로 차단됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
