### PR TITLE
보안 취약점 2종 수정 (저장형XSS 출력인코딩 누락/미사용 IDOR DAO 제거) - 6차

### DIFF
--- a/src/main/java/meminfo/model/MemInfoDao.java
+++ b/src/main/java/meminfo/model/MemInfoDao.java
@@ -618,26 +618,9 @@ public class MemInfoDao {
 			return list;
 		}
 
-		//유지)휴게소 즐겨찾기 f_num으로 삭제
-		public void favDelete(String f_num) {
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-
-			String sql="delete from favorite where f_num=?";
-
-			try {
-				pstmt=conn.prepareStatement(sql);
-				pstmt.setString(1, f_num);
-				pstmt.execute();
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(pstmt, conn);
-			}
-		}
-
 		// 소유자 범위 즐겨찾기 삭제 (IDOR 방어: 세션 m_num 소유분만 삭제)
+		// 주의) 소유자 조건 없는 PK-only favDelete(String) 오버로드는 IDOR 위험으로 제거함.
+		//       즐겨찾기 삭제는 반드시 아래 2-인자(f_num, m_num) 메서드만 사용한다.
 		public void favDelete(String f_num, String m_num) {
 			Connection conn=db.getConnection();
 			PreparedStatement pstmt=null;

--- a/src/main/webapp/foodcourt/choicehuegeso.jsp
+++ b/src/main/webapp/foodcourt/choicehuegeso.jsp
@@ -112,7 +112,7 @@ List<HugesoInfoDto> list=dao.getH_numH_name();
   <%
   	for(int i=0;i<list.size();i++){
   		HugesoInfoDto dto=list.get(i);%>
-  		 <li><a class="dropdown-item gomenu" h_num="<%=dto.getH_num() %>"><%=dto.getH_name() %></a></li>
+  		 <li><a class="dropdown-item gomenu" h_num="<%=dto.getH_num() %>"><%=util.SecurityUtil.escapeHtml(dto.getH_name()) %></a></li>
   	<%}
   %>
   

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -239,7 +239,7 @@ NumberFormat nf=NumberFormat.getInstance();
 		<%-- <img alt="" src="image/mainbanner/memberbanner01.jpg">--%>
 </div>
 <div class="span-container" style="border:0px solid purple; font-size: 2.5em;" >
-	<span> <%=hdto.getH_name() %>의 주문가능 메뉴<br>
+	<span> <%=util.SecurityUtil.escapeHtml(hdto.getH_name()) %>의 주문가능 메뉴<br>
 	<span style="display: block;font-size: 10pt;">*상기이미지는 실제메뉴와 차이가 있을 수 있습니다.*</span>
 	</span>
 </div>
@@ -259,8 +259,8 @@ NumberFormat nf=NumberFormat.getInstance();
 		<a class="menuchoice" f_num="<%=f_num%>">
 		<img alt="" src="fileview?type=hugeso&name=<%=util.SecurityUtil.urlEncode(dto.getF_photo())%>" style="width: 230px;;height: 200px;cursor: pointer;">
 		<div>
-			<span><%=dto.getF_name() %></span>
-			<span><%= nf.format(pr) %>원</span><br>	
+			<span><%=util.SecurityUtil.escapeHtml(dto.getF_name()) %></span>
+			<span><%= nf.format(pr) %>원</span><br>
 		</div>
 		</a>
 		<div>

--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -349,9 +349,9 @@ for(int i=0;i<list2.size();i++){
     <tr>
     <td>
     <a href="index.jsp?main=hugesoinfo/hugesodetail.jsp?h_num=<%=hdto.getH_num() %>">
-    <%=hdto.getH_name() %></a></td>
-    <td><%=hdto.getH_addr() %> </td>
-    <td><%=hdto.getH_hp() %> </td>
+    <%=util.SecurityUtil.escapeHtml(hdto.getH_name()) %></a></td>
+    <td><%=util.SecurityUtil.escapeHtml(hdto.getH_addr()) %> </td>
+    <td><%=util.SecurityUtil.escapeHtml(hdto.getH_hp()) %> </td>
     <td>
  <% 
         String pyeons = hdto.getH_pyeon(); //dto에 있는 편의시설 문자열을 pyeons에 넣어줌

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -279,9 +279,9 @@ for (int i = 0; i < list2.size(); i++) {
 %>
 	   
 			<div style="width: 250px; height: 250px;  border: 1px solid lightgray; margin: 0 auto 20px auto;"><img alt="" src="fileview?type=hugeso&name=<%= util.SecurityUtil.urlEncode(dto.getH_photo()) %>" style="width: 250px; height: 250px; object-fit: cover;"></div>
-          	<a href="index.jsp?main=hugesoinfo/hugesodetail.jsp?h_num=<%= dto.getH_num() %>" style="font-weight:bold;"><%=dto.getH_name() %></a>
-            <p style="color: gray; font-size: 9pt; font-weight: bold; margin-bottom: 0px;"><%=dto.getH_addr() %></p>
-            <p style="color: lightgray; font-size: 9pt; font-weight: bold;"><%=dto.getH_hp() %></p>
+          	<a href="index.jsp?main=hugesoinfo/hugesodetail.jsp?h_num=<%= dto.getH_num() %>" style="font-weight:bold;"><%=util.SecurityUtil.escapeHtml(dto.getH_name()) %></a>
+            <p style="color: gray; font-size: 9pt; font-weight: bold; margin-bottom: 0px;"><%=util.SecurityUtil.escapeHtml(dto.getH_addr()) %></p>
+            <p style="color: lightgray; font-size: 9pt; font-weight: bold;"><%=util.SecurityUtil.escapeHtml(dto.getH_hp()) %></p>
         </div>
 <%
     count++;

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -250,9 +250,9 @@ if(list2.isEmpty()){
 	%>
 		   
 				<div style="width: 250px; height: 250px;  border: 1px solid lightgray; margin: 0 auto 20px auto;"><img alt="" src="fileview?type=hugeso&name=<%= util.SecurityUtil.urlEncode(dto.getH_photo()) %>" style="width: 250px; height: 250px;"></div>
-	          	<a href="index.jsp?main=hugesoinfo/hugesodetail.jsp?h_num=<%= dto.getH_num() %>" style="font-weight:bold;"><%=dto.getH_name() %></a>
-	            <p style="color: gray; font-size: 9pt; font-weight: bold; margin-bottom: 0px;"><%=dto.getH_addr() %></p>
-	            <p style="color: lightgray; font-size: 9pt; font-weight: bold;"><%=dto.getH_hp() %></p>
+	          	<a href="index.jsp?main=hugesoinfo/hugesodetail.jsp?h_num=<%= dto.getH_num() %>" style="font-weight:bold;"><%=util.SecurityUtil.escapeHtml(dto.getH_name()) %></a>
+	            <p style="color: gray; font-size: 9pt; font-weight: bold; margin-bottom: 0px;"><%=util.SecurityUtil.escapeHtml(dto.getH_addr()) %></p>
+	            <p style="color: lightgray; font-size: 9pt; font-weight: bold;"><%=util.SecurityUtil.escapeHtml(dto.getH_hp()) %></p>
 	        </div>
 	<%
 	    count++;

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -316,9 +316,9 @@ if(list2.isEmpty()){
 	    <tr>
 	    <td>
 	    <a href="index.jsp?main=hugesoinfo/hugesodetail.jsp?h_num=<%=hdto.getH_num() %>">
-	    <%=hdto.getH_name() %></a></td>
-	    <td><%=hdto.getH_addr() %> </td>
-	    <td><%=hdto.getH_hp() %> </td>
+	    <%=util.SecurityUtil.escapeHtml(hdto.getH_name()) %></a></td>
+	    <td><%=util.SecurityUtil.escapeHtml(hdto.getH_addr()) %> </td>
+	    <td><%=util.SecurityUtil.escapeHtml(hdto.getH_hp()) %> </td>
 	    <td>
 	 <% 
 	        String pyeons = hdto.getH_pyeon(); //dto에 있는 편의시설 문자열을 pyeons에 넣어줌

--- a/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
@@ -109,7 +109,7 @@
 		$(function(){
 			var map=createMap();
 			
-			searchHugeso("<%=hdto.getH_addr() %>", map);
+			searchHugeso("<%=util.SecurityUtil.escapeJs(hdto.getH_addr()) %>", map);
 			
 			// 휴게소 주소 입력란의 내용이 변경될 때마다 searchHugeso 함수 실행
 	        $("#h_addr").keyup(function(){
@@ -165,8 +165,8 @@
 				for(int i=1;i<=blist.size();i++){
 					BrandDto bdto=blist.get(i-1);
 					%>
-					$("#brandaddarea input[type='text'][name='b_name"+<%=i %>+"']").attr("value","<%=bdto.getB_name() %>");
-					$("#brandaddarea input[type='text'][name='b_addr"+<%=i %>+"']").attr("value","<%=bdto.getB_addr() %>");
+					$("#brandaddarea input[type='text'][name='b_name"+<%=i %>+"']").attr("value","<%=util.SecurityUtil.escapeJs(bdto.getB_name()) %>");
+					$("#brandaddarea input[type='text'][name='b_addr"+<%=i %>+"']").attr("value","<%=util.SecurityUtil.escapeJs(bdto.getB_addr()) %>");
 					$("#brandaddarea input[type='hidden'][name='b_num"+<%=i %>+"']").attr("value","<%=bdto.getB_num() %>");
 					<%
 				}
@@ -174,7 +174,7 @@
 				for(int i=1;i<=flist.size();i++){
 					FoodDto fdto=flist.get(i-1);
 					%>
-					$("#foodaddarea input[type='text'][name='f_name"+<%=i %>+"']").attr("value","<%=fdto.getF_name() %>");
+					$("#foodaddarea input[type='text'][name='f_name"+<%=i %>+"']").attr("value","<%=util.SecurityUtil.escapeJs(fdto.getF_name()) %>");
 					$("#foodaddarea input[type='text'][name='f_price"+<%=i %>+"']").attr("value","<%=fdto.getF_price() %>");
 					$("#foodaddarea input[type='hidden'][name='f_num"+<%=i %>+"']").attr("value","<%=fdto.getF_num() %>");
 					<%
@@ -291,15 +291,15 @@
 		<div id="contentarea">
 			<form action="hugesoinfo/hugesoupdateaction.jsp" id="frm" method="post" enctype="multipart/form-data">
 				<input type="hidden" name="h_num" value="<%=h_num %>">
-				<div>휴게소 이름: <input type="text" name="h_name" required="required" value="<%=hdto.getH_name() %>"></div>
+				<div>휴게소 이름: <input type="text" name="h_name" required="required" value="<%=util.SecurityUtil.escapeHtml(hdto.getH_name()) %>"></div>
 				<hr>
 				<div>휴게소 사진: <input type="file" name="h_photo"></div>
 				<hr>
-				<div>휴게소 번호: <input type="text" name="h_hp1" maxlength="3" size="3" required="required" value="<%=hpArray[0] %>"> - <input type="text" name="h_hp2" maxlength="4" size="4" required="required" value="<%=hpArray[1] %>"> - <input type="text" name="h_hp3" maxlength="4" size="4" required="required" value="<%=hpArray[2] %>"></div>
+				<div>휴게소 번호: <input type="text" name="h_hp1" maxlength="3" size="3" required="required" value="<%=util.SecurityUtil.escapeHtml(hpArray[0]) %>"> - <input type="text" name="h_hp2" maxlength="4" size="4" required="required" value="<%=util.SecurityUtil.escapeHtml(hpArray[1]) %>"> - <input type="text" name="h_hp3" maxlength="4" size="4" required="required" value="<%=util.SecurityUtil.escapeHtml(hpArray[2]) %>"></div>
 				<hr>
-				<div>휴게소 주소: <input type="text" name="h_addr" id="h_addr" required="required" value="<%=hdto.getH_addr() %>"></div>
-				<input type="hidden" name="h_xvalue" id="h_xvalue" value="<%=hdto.getH_xvalue() %>">
-				<input type="hidden" name="h_yvalue" id="h_yvalue" value="<%=hdto.getH_yvalue() %>">
+				<div>휴게소 주소: <input type="text" name="h_addr" id="h_addr" required="required" value="<%=util.SecurityUtil.escapeHtml(hdto.getH_addr()) %>"></div>
+				<input type="hidden" name="h_xvalue" id="h_xvalue" value="<%=util.SecurityUtil.escapeHtml(hdto.getH_xvalue()) %>">
+				<input type="hidden" name="h_yvalue" id="h_yvalue" value="<%=util.SecurityUtil.escapeHtml(hdto.getH_yvalue()) %>">
 				<hr>
 				<div>
 					편의시설: 
@@ -331,9 +331,9 @@
 				<div class="btnarea"><button type="button" id="addfood" >메뉴 추가</button></div>
 				<hr>
 				<div>
-					휘발유: <input type="text" name="h_gasolin" value="<%=hdto.getH_gasolin() %>" style="text-align: right;">원&nbsp;/
-					경유: <input type="text" name="h_disel" value="<%=hdto.getH_disel() %>" style="text-align: right;">원&nbsp;/
-					천연가스: <input type="text" name="h_lpg" value="<%=hdto.getH_lpg() %>" style="text-align: right;">원&nbsp;
+					휘발유: <input type="text" name="h_gasolin" value="<%=util.SecurityUtil.escapeHtml(hdto.getH_gasolin()) %>" style="text-align: right;">원&nbsp;/
+					경유: <input type="text" name="h_disel" value="<%=util.SecurityUtil.escapeHtml(hdto.getH_disel()) %>" style="text-align: right;">원&nbsp;/
+					천연가스: <input type="text" name="h_lpg" value="<%=util.SecurityUtil.escapeHtml(hdto.getH_lpg()) %>" style="text-align: right;">원&nbsp;
 				</div>
 				<hr>
 				<div class="btnarea">

--- a/src/main/webapp/mainlayout/foodrank.jsp
+++ b/src/main/webapp/mainlayout/foodrank.jsp
@@ -121,7 +121,7 @@
                 display: inline-block;">
                     <img alt="" src="fileview?type=hugeso&name=<%=util.SecurityUtil.urlEncode(dto.getF_photo())%>" class="f_image">
                     <div class="f_food">
-                        <div class="f_name" style="font-size: 0.85em;"><%=dto.getF_name() %></div>
+                        <div class="f_name" style="font-size: 0.85em;"><%=util.SecurityUtil.escapeHtml(dto.getF_name()) %></div>
                         <div class="f_addr" style="font-size: 0.7em;"><%=nf.format(price) %>원</div>
                     </div>
                 </a>

--- a/src/main/webapp/reviewboard/reviewForm.jsp
+++ b/src/main/webapp/reviewboard/reviewForm.jsp
@@ -46,7 +46,7 @@
                <select name="r_category" id="r_category" class="form-control" required="required" 
                style="width: 200px;">
                  <% for (HugesoInfoDto hugeso : hlist) { %>
-                     <option value="<%= hugeso.getH_name() %>"><%= hugeso.getH_name() %></option>
+                     <option value="<%= util.SecurityUtil.escapeHtml(hugeso.getH_name()) %>"><%= util.SecurityUtil.escapeHtml(hugeso.getH_name()) %></option>
                  <% } %>
                </select>
              </td>

--- a/src/main/webapp/reviewboard/reviewUpdateForm.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateForm.jsp
@@ -81,7 +81,7 @@
                <select name="r_category" id="r_category" class="form-control" required="required" 
                style="width: 200px;">
                  <% for (HugesoInfoDto hugeso : hlist) { %>
-                     <option value="<%= hugeso.getH_name() %>"><%= hugeso.getH_name() %></option>
+                     <option value="<%= util.SecurityUtil.escapeHtml(hugeso.getH_name()) %>"><%= util.SecurityUtil.escapeHtml(hugeso.getH_name()) %></option>
                  <% } %>
                </select>
              </td>

--- a/src/main/webapp/shop/shopForm.jsp
+++ b/src/main/webapp/shop/shopForm.jsp
@@ -42,7 +42,7 @@
                <select name="s_category" id="s_category" class="form-control" required="required" 
                style="width: 200px;">
                  <% for (HugesoInfoDto hugeso : hlist) { %>
-                     <option value="<%= hugeso.getH_name() %>"><%= hugeso.getH_name() %></option>
+                     <option value="<%= util.SecurityUtil.escapeHtml(hugeso.getH_name()) %>"><%= util.SecurityUtil.escapeHtml(hugeso.getH_name()) %></option>
                  <% } %>
                </select>
              </td>


### PR DESCRIPTION
## 개요
신규 세션에서 시큐어 코드 리뷰를 전수 재검증한 결과 발견된 잔존 취약점 2종을 수정합니다. 대부분의 1~5차 보호는 실제로 적용되어 있었으나, 관리자 입력 필드의 출력 인코딩에 사각지대가 남아 있었습니다.

## 변경 사항

### [Medium] 저장형 XSS — 관리자 입력 필드 출력 인코딩 누락 일괄 수정
관리자 전용 휴게소/브랜드/음식 관리 화면에서 저장되는 `h_name`/`h_addr`/`h_hp`/`f_name`/`b_name`/`b_addr` 등이 5차까지 `hugesodetail`/`hugesorank`에서만 인코딩되고, **목록·검색·메뉴·랭킹·select 옵션·관리 수정폼에서는 raw로 출력**되던 사각지대를 기존 헬퍼로 일괄 정리했습니다(정책 일관성 확보).

- **HTML 본문/속성 → `SecurityUtil.escapeHtml`**
  - `hugesoinfo/hugesolist.jsp`, `hugesolist2.jsp`, `hugesolist2search.jsp`, `hugesolistsearch.jsp` (h_name/h_addr/h_hp)
  - `foodcourt/choicehuegeso.jsp`(h_name), `foodcourt/foodmenu.jsp`(h_name/f_name), `mainlayout/foodrank.jsp`(f_name)
  - `reviewboard/reviewForm.jsp`, `reviewboard/reviewUpdateForm.jsp`, `shop/shopForm.jsp` 의 select option(value+text)
  - `hugesoinfo/hugesoupdateform.jsp` 의 value 속성(h_name/h_addr/전화번호 3분할/좌표/연료가 3종)
- **인라인 JS 문자열 → `SecurityUtil.escapeJs`**
  - `hugesoinfo/hugesoupdateform.jsp` 의 `searchHugeso()` 인자 및 b_name/b_addr/f_name setter

### [Low] 미사용 IDOR 위험 DAO 제거
- `meminfo/model/MemInfoDao.java` 의 소유자 조건 없는 1-인자 `favDelete(String)` 데드코드 제거. 호출부는 모두 2-인자(`f_num`, `m_num`) 소유자 범위 버전을 사용함을 확인. 향후 오용 방지 주석 추가.

## 오탐으로 기각(재검증 완료)
- `qaAnswerOneData.jsp` JSON `qa_content`: 소비처가 text input `.val()`(HTML 파싱 없음) → sink 아님
- `qaUpdateForm.jsp` option: value가 고정 리터럴, 나머지 필드는 이미 escape됨
- `qaDetail` 댓글목록 `.html()`: `qaListAction.jsp`에서 qa_myid/qa_content 모두 escape됨
- SQLi/파일업로드/인증·세션/회원가입 mass-assignment/index.jsp 화이트리스트/설정: 모두 방어 확인

## 검증
- `src/main/java` 전체 `javac` 컴파일 성공(EXIT=0) — DAO 메서드 제거 후 잔존 참조 없음
- `escapeHtml`/`escapeJs` 시그니처(String→String) 및 대상 DTO getter 타입 정합 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)