### PR TITLE
보안 취약점 3종 수정 (속성 인젝션/JSON 일관 인코딩/검색 URL 견고성)

### DIFF
--- a/src/main/webapp/foodgrade/foodgradesort.jsp
+++ b/src/main/webapp/foodgrade/foodgradesort.jsp
@@ -34,7 +34,7 @@
         htmlBuilder.append("<div class=\"food-item\" style=\"text-align: center; font-weight: bold; margin-bottom: 20px; margin-right: 20px; cursor: pointer;\" data-fnum=\"")
                    .append(dto.getF_num())
                    .append("\">")
-                   .append("<img alt=\"").append(util.SecurityUtil.escapeHtml(dto.getF_name())).append("\" src=\"image/food/").append(dto.getF_photo())
+                   .append("<img alt=\"").append(util.SecurityUtil.escapeHtml(dto.getF_name())).append("\" src=\"image/food/").append(util.SecurityUtil.escapeHtml(dto.getF_photo()))
                    .append("\" style=\"width: 220px; height: 200px; margin-bottom: 15px;\" data-fnum=\"").append(dto.getF_num()).append("\"><br>")
                    .append("<div style=\"display: inline-block;\" class=\"starrating\">")
                    .append("<label style=\"-webkit-text-fill-color: gold; font-size: 15px;\">★</label>")

--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -278,7 +278,7 @@ function searchAction(h_name){
 	if(h_name==""){
 		alert("검색어를 입력해주세요");
 	} else{
-		location.href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?h_name="+h_name;
+		location.href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?h_name="+encodeURIComponent(h_name);
 	}
 }
 

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -232,7 +232,7 @@ function searchAction(h_name){
 	if(h_name==""){
 		alert("검색어를 입력해주세요");
 	} else{
-		location.href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?h_name="+h_name;
+		location.href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?h_name="+encodeURIComponent(h_name);
 	}
 }
 

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -198,7 +198,7 @@ function searchAction(h_name){
 	if(h_name==""){
 		alert("검색어를 입력해주세요");
 	} else{
-		location.href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?h_name="+h_name;
+		location.href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?h_name="+encodeURIComponent(h_name);
 	}
 }
 

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -242,7 +242,7 @@ function searchAction(h_name){
 	if(h_name==""){
 		alert("검색어를 입력해주세요");
 	} else{
-		location.href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?h_name="+h_name;
+		location.href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?h_name="+encodeURIComponent(h_name);
 	}
 }
 

--- a/src/main/webapp/qaanswer/qaAnswerOneData.jsp
+++ b/src/main/webapp/qaanswer/qaAnswerOneData.jsp
@@ -13,7 +13,7 @@
     JSONObject ob = new JSONObject();
     ob.put("q_num", dto.getQ_num());
     ob.put("qa_num", dto.getQa_num());
-    ob.put("qa_content", dto.getQa_content());
+    ob.put("qa_content", util.SecurityUtil.escapeHtml(dto.getQa_content()));
     
     %>
     


### PR DESCRIPTION
## 개요
신규 세션에서 시큐어 코드 리뷰를 재수행했다. 1~6차 누적 수정을 "이미 적용됨"으로 신뢰하지 않고 코드로 직접 재검증했으며, 변형/형제 페이지(list2, search2, 액션 형제)와 JSON 소비처 sink(`.html()` vs `.val()`)를 중점 확인했다.

**재검증 결론:** 접근제어/IDOR/SQLi/업로드/인증·세션/설정은 모두 적용·유효하며 Critical/High 신규 취약점 없음. 본 PR은 잔여 Low/심층방어 3종을 마무리한다.

## 변경 사항

| 항목 | 파일 | 내용 |
|---|---|---|
| **F-1** [Low] 속성 인젝션 | `foodgrade/foodgradesort.jsp` | `img src` 속성의 `f_photo`를 `escapeHtml` 처리. `f_name`은 인코딩돼 있었으나 `f_photo`는 raw 출력되어 업로드 파일명 기반 속성 탈출 가능성이 있었음 |
| **F-2** [Low/방어] JSON 일관 인코딩 | `qaanswer/qaAnswerOneData.jsp` | JSON `qa_content`를 `escapeHtml` 처리. 현재 소비처는 `.val()` 삽입이라 sink는 아니나, 형제 `qaListAction.jsp`와 통일하고 향후 `.html()` 소비 시 회귀 방지 |
| **F-3** [방어] 검색 URL 견고성 | `hugesolist.jsp`, `hugesolist2.jsp`, `hugesolistsearch.jsp`, `hugesolist2search.jsp` | `searchAction`의 `h_name`을 `encodeURIComponent`로 인코딩. XSS는 아니나 `&`,`#`,공백 등 특수문자 검색어가 쿼리 구조를 깨지 않도록 보강 |

## 오탐 재확인 (코드로 검증, 신규 보고 아님)
- `location.href + h_name`: 목적지가 `h_name`을 raw 재출력하지 않고(검색창은 빈 `input`, 본문은 `urlEncode`된 href만), `isAllowedMainPage`가 `?` 기준 쿼리스트링을 잘라 화이트리스트 매칭. 비-`javascript:` URL의 `location.href` 대입은 단순 이동 → XSS 아님.
- `qaAnswerOneData.jsp` `qa_content`: 소비처 키 불일치(`res.uqa_content`=undefined) + `.val()` 삽입 → sink 아님.

## 검증
- 기존 헬퍼만 재사용(`SecurityUtil.escapeHtml(String)`), `getF_photo()`/`getQa_content()` 반환 타입 String 정합 확인. JSP 스크립틀릿만 변경되어 Java 타입 트리 영향 없음.
- 잔여 `f_photo` 출력 전수 확인: `foodgradesort.jsp:89`는 JSP 주석 내 데드코드, `hugesodetail.jsp`는 이미 `fileview + urlEncode` 처리됨.

## 범위 밖 (위험도만 기록)
- 상태변경 GET + CSRF 토큰 미적용(SameSite=Lax만) — 잔존 Medium, 별도 과제 권고
- `printStackTrace` 다수(error-page로 노출 차단, Low), 빈 껍데기 액션 파일 2종(데드코드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)