### PR TITLE
보안 취약점 4종 수정 — 저장형/DOM XSS 출력인코딩 누락 (8차)

### DIFF
--- a/src/main/webapp/foodcourt/foodcartlist.jsp
+++ b/src/main/webapp/foodcourt/foodcartlist.jsp
@@ -21,7 +21,8 @@ for(HashMap<String,String> map:list){
 	int total=cnt*price;
 	
 	for(String key:map.keySet()){
-		ob.put("f_name", map.get("f_name"));
+		// DOM 저장형 XSS 방어: f_name이 클라이언트 .html()로 삽입되므로 서버측에서 HTML 이스케이프
+		ob.put("f_name", util.SecurityUtil.escapeHtml(map.get("f_name")));
 		ob.put("cart_cnt", map.get("cart_cnt"));
 		ob.put("f_price", map.get("f_price"));
 		ob.put("cart_total", total);

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -1114,15 +1114,15 @@ toggleContent("hiddenContent1", "moreButton1", "foldButton1", "brand-item", docu
 </tr>
 <tr>
     <td>휘발유</td>
-    <td><%= "없음".equals(dto.getH_gasolin()) ? "-" : dto.getH_gasolin() %>원</td>
+    <td><%= util.SecurityUtil.escapeHtml("없음".equals(dto.getH_gasolin()) ? "-" : dto.getH_gasolin()) %>원</td>
 </tr>
 <tr>
     <td>경유</td>
-    <td><%= "없음".equals(dto.getH_disel()) ? "-" : dto.getH_disel() %>원</td>
+    <td><%= util.SecurityUtil.escapeHtml("없음".equals(dto.getH_disel()) ? "-" : dto.getH_disel()) %>원</td>
 </tr>
 <tr>
     <td>LPG</td>
-    <td><%= "없음".equals(dto.getH_lpg()) ? "-" : dto.getH_lpg() %>원</td>
+    <td><%= util.SecurityUtil.escapeHtml("없음".equals(dto.getH_lpg()) ? "-" : dto.getH_lpg()) %>원</td>
 </tr>
 
 </table>
@@ -1162,7 +1162,7 @@ toggleContent("hiddenContent1", "moreButton1", "foldButton1", "brand-item", docu
 <% if(!G_myid) {%> 
          <div class="gradefrm" id="insertgrade">
           <div style="display: inline-block;">
-          <p style="margin-top:80px; font-size 20px; font-weight:bold;"><%=m_id %></p>
+          <p style="margin-top:80px; font-size 20px; font-weight:bold;"><%=util.SecurityUtil.escapeHtml(m_id) %></p>
 
 
     <div class="star-rating space-x-4 mx-auto" id="g_grade";>

--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -418,7 +418,8 @@ for(int i=0;i<list2.size();i++){
     if(blist.size()>0){
     	for(int j=0;j<blist.size();j++){
         	BrandDto bdto=blist.get(j);
-        	brandList.add(bdto.getB_name());
+        	// 저장형 XSS 방어: 브랜드명을 목록 출력 전 HTML 이스케이프
+        	brandList.add(util.SecurityUtil.escapeHtml(bdto.getB_name()));
         }
     } else{
     	brandList.add("없음");

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -385,7 +385,8 @@ if(list2.isEmpty()){
 		  if(brandList.size()>0){
 		  	for(int j=0;j<blist.size();j++){
 		      	BrandDto bdto=blist.get(j);
-		       	brandList.add(bdto.getB_name());
+		       	// 저장형 XSS 방어: 브랜드명을 목록 출력 전 HTML 이스케이프
+		       	brandList.add(util.SecurityUtil.escapeHtml(bdto.getB_name()));
 		       }
 		    } else{
 		    	brandList.add("없음");


### PR DESCRIPTION
## 개요
8차 시큐어 코드 리뷰에서 **상세 페이지에만 출력 인코딩이 적용되고 목록/JSON 경로에서 누락된** 저장형/DOM XSS 사각지대 4종을 일괄 보강했습니다. 동작·쿼리·스키마 변경 없이 `util.SecurityUtil.escapeHtml` 출력 인코딩만 추가한 저위험 변경입니다.

## 수정 내역
| 심각도 | 위치 | 내용 |
|---|---|---|
| **High** | `hugesoinfo/hugesolist.jsp`, `hugesoinfo/hugesolistsearch.jsp` | 브랜드명 `B_name`을 `brandList` 빌드 시 `escapeHtml` 적용(단일/다중 출력 분기 모두 커버). detail은 이미 적용돼 있었으나 목록 변형 경로에서 누락된 사각지대 |
| **Medium** | `foodcourt/foodcartlist.jsp` | `.html()` sink(`foodmenu.jsp`)로 삽입되는 `f_name`을 서버측 JSON 생성 시 `escapeHtml` (기존 `gradelist.jsp` 패턴) |
| **Medium** | `hugesoinfo/hugesodetail.jsp` | 자유입력 유가 필드 `H_gasolin/H_disel/H_lpg` 삼항식 결과 `escapeHtml` |
| **Low** | `hugesoinfo/hugesodetail.jsp` | 세션 `m_id` 출력 인코딩 일관성 보강(`escapeHtml`, null-safe) |

## 검증
- 대상 getter/맵값/세션값이 모두 `String` 타입임을 확인 → `escapeHtml(String)` 인자 정합
- `escapeHtml` null-safe(null→`""`) 확인
- `javac -encoding UTF-8`로 `src/main/java` 전체 컴파일 통과
- 정상 브랜드명/음식명/가격은 그대로 표시, `"><script>`·`<img onerror>` 류는 텍스트로 escape

## 범위 밖(기존 의도적 후속과제, 미수정)
- GET 상태변경 + CSRF 토큰 미적용(SameSite=Lax 전역 방어만)
- `printStackTrace` 로거 미전환
- `foodcartlist.jsp`의 `m_num/h_num` 무인증 조회(읽기 IDOR, Low)
- 빈 껍데기 액션 파일, `foodgradesort.jsp` 이미지 옛 경로

🤖 Generated with [Claude Code](https://claude.com/claude-code)
