### PR TITLE
보안 취약점 수정 10차: 추천 CSRF/접근제어 누락 보강 · 상태변경 GET→POST 전환 · XSS 사각지대

### DIFF
--- a/src/main/java/util/SecurityUtil.java
+++ b/src/main/java/util/SecurityUtil.java
@@ -438,6 +438,14 @@ public class SecurityUtil {
 	 * 요청 파라미터 _csrf가 세션 토큰과 일치하는지 상수시간 비교로 검증한다.
 	 * 상태 변경(POST) 액션 진입부에서 호출하고, false면 요청을 거부한다.
 	 */
+	/**
+	 * 요청이 POST 메서드인지 검사한다. 상태 변경 액션은 GET으로 호출되면 안 되므로
+	 * (프리패치·캐싱·&lt;img&gt; 트리거 등 위험) 진입부에서 isPost+checkCsrf를 함께 검증한다.
+	 */
+	public static boolean isPost(HttpServletRequest request) {
+		return request != null && "POST".equalsIgnoreCase(request.getMethod());
+	}
+
 	public static boolean checkCsrf(HttpServletRequest request) {
 		if (request == null) {
 			return false;

--- a/src/main/webapp/eventboard/eventAction.jsp
+++ b/src/main/webapp/eventboard/eventAction.jsp
@@ -42,7 +42,7 @@
     	multi = new MultipartRequest(request, uploadPath, uploadSize, "utf-8", new DefaultFileRenamePolicy());
 
     	//CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-    	if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+    	if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
     		<script type="text/javascript">
     			alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/eventboard/eventChu.jsp
+++ b/src/main/webapp/eventboard/eventChu.jsp
@@ -1,35 +1,24 @@
 <%@page import="org.json.simple.JSONObject"%>
 <%@page import="event.model.EventDao"%>
-<%@ page language="java" contentType="text/html; charset=UTF-8"
+<%@ page language="java" contentType="application/json; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<!DOCTYPE html>
-<html>
-<head>
-<meta charset="UTF-8">
-    <link href="https://fonts.googleapis.com/css2?family=Nanum+Brush+Script&family=Nanum+Pen+Script&family=Noto+Sans+KR:wght@100..900&family=Noto+Serif+KR&family=Stylish&display=swap" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
-</head>
-<body>
+<%
+  // 상태변경(추천수 +1)이므로 POST + 로그인 + CSRF를 강제한다.
+  if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.isLogin(session)
+        || !util.SecurityUtil.checkCsrf(request)){
+      response.sendError(HttpServletResponse.SC_FORBIDDEN);
+      return;
+  }
 
-  <%
-    //num 읽기
-    String e_num = request.getParameter("e_num");
-    
-    EventDao dao = new EventDao();
-    dao.updateEventChu(e_num);
-    
-    //증가된 chu 값 json 형태로 보내기
-    int chu = dao.getDataEvent(e_num).getE_chu();
-    
-    JSONObject ob = new JSONObject();
-    ob.put("chu", chu);
-    
-    %>
-    
-    <%=ob.toString()%>
+  String e_num = util.SecurityUtil.digitsOnly(request.getParameter("e_num"));
 
-</body>
-</html>
+  EventDao dao = new EventDao();
+  dao.updateEventChu(e_num);
+
+  // 증가된 chu 값 json 형태로 보내기
+  int chu = dao.getDataEvent(e_num).getE_chu();
+
+  JSONObject ob = new JSONObject();
+  ob.put("chu", chu);
+%>
+<%=ob.toString()%>

--- a/src/main/webapp/eventboard/eventDelete.jsp
+++ b/src/main/webapp/eventboard/eventDelete.jsp
@@ -18,8 +18,8 @@
   if(!util.SecurityUtil.isAdmin(session)){
     response.sendRedirect("../index.jsp?main=eventboard/eventList.jsp"); return;
   }
-  // CSRF 토큰 검증(위조 요청 차단)
-  if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+  // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+  if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
   String e_num=request.getParameter("e_num");
   String currentPage=request.getParameter("currentPage");
 

--- a/src/main/webapp/eventboard/eventDetail.jsp
+++ b/src/main/webapp/eventboard/eventDetail.jsp
@@ -63,7 +63,7 @@
 		  
 		  
 		  $.ajax ({
-			type : "get",
+			type : "post",
 			dataType : "json",
 			url : "eventboard/eventChu.jsp",
 			data : {"e_num":e_num},
@@ -90,7 +90,7 @@
 	  var ans=confirm("삭제하려면 [확인]을 눌러주세요");
 	   
 	   if(ans){
-		   location.href='eventboard/eventDelete.jsp?e_num='+e_num+"&currentPage="+currentPage+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+		   postNav('eventboard/eventDelete.jsp', {e_num:e_num, currentPage:currentPage});
 	   } 
   }
  

--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -236,7 +236,7 @@
         		    width: 250px; display: block;"><%=util.SecurityUtil.escapeHtml(dto.getE_subject()) %></span></a>
         		    
         		    </td>
-        		    <td align="center"><%=name %></td>
+        		    <td align="center"><%=util.SecurityUtil.escapeHtml(name) %></td>
         		    <td align="center"><%=dto.getE_readcount() %></td>
         		    <td align="center"><%=dto.getE_chu()%></td>
         		    <td align="center"><%=sdf.format(dto.getE_writeday())%></td>

--- a/src/main/webapp/eventboard/eventUpdateAction.jsp
+++ b/src/main/webapp/eventboard/eventUpdateAction.jsp
@@ -35,7 +35,7 @@
   multi=new MultipartRequest(request,realPath,uploadSize,"utf-8",new DefaultFileRenamePolicy());
 
        //CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-       if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+       if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
        <script type="text/javascript">
            alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/foodcourt/cartalldelete.jsp
+++ b/src/main/webapp/foodcourt/cartalldelete.jsp
@@ -6,8 +6,8 @@
 if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
-// CSRF 토큰 검증(위조 요청 차단)
-if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
 FoodCartDao dao=new FoodCartDao();
 dao.deleteAllCart(m_num);

--- a/src/main/webapp/foodcourt/foodcartaddaction.jsp
+++ b/src/main/webapp/foodcourt/foodcartaddaction.jsp
@@ -17,8 +17,8 @@
 if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
-// CSRF 토큰 검증(위조 요청 차단)
-if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 String f_num=request.getParameter("f_num");
 String h_num=request.getParameter("h_num");
 String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));

--- a/src/main/webapp/foodcourt/foodcartdelete.jsp
+++ b/src/main/webapp/foodcourt/foodcartdelete.jsp
@@ -6,8 +6,8 @@
 if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
-// CSRF 토큰 검증(위조 요청 차단)
-if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 String cart_idx=request.getParameter("cart_idx");
 // 소유자는 클라이언트 입력을 신뢰하지 않고 세션 사용자로부터 서버에서 도출(IDOR 방지)
 String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -166,7 +166,7 @@ $(function(){
 		 
 		
 		$.ajax({
-			type:"get",
+			type:"post",
 			url:"foodcourt/foodcartdelete.jsp",
 			data:{"cart_idx":cart_idx},
 			dataType:"html",
@@ -375,7 +375,7 @@ var m_num=$("#m_num").val();
 
 function deleteAllCart() {
     $.ajax({
-        type: "get",
+        type: "post",
         url: "foodcourt/cartalldelete.jsp",
         data:{"m_num":m_num},
         dataType:"html",

--- a/src/main/webapp/foodgrade/insertfoodgrade.jsp
+++ b/src/main/webapp/foodgrade/insertfoodgrade.jsp
@@ -7,8 +7,8 @@
   if(!util.SecurityUtil.isLogin(session)){
     response.sendError(403); return;
   }
-  // CSRF 토큰 검증(위조 요청 차단)
-  if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+  // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+  if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 %>
 <jsp:useBean id="dao" class="foodgrade.model.FoodGradeDao"/>
 <jsp:useBean id="dto" class="foodgrade.model.FoodGradeDto"/>

--- a/src/main/webapp/foodgrade/updatef_grade.jsp
+++ b/src/main/webapp/foodgrade/updatef_grade.jsp
@@ -10,8 +10,8 @@
     if(!util.SecurityUtil.isLogin(session)){
         response.sendError(403); return;
     }
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
     String h_num = util.SecurityUtil.digitsOnly(request.getParameter("h_num"));
     String f_num = util.SecurityUtil.digitsOnly(request.getParameter("f_num"));
     String fg_foodnum = f_num;

--- a/src/main/webapp/grade/deletegrade.jsp
+++ b/src/main/webapp/grade/deletegrade.jsp
@@ -7,8 +7,8 @@
     if(!util.SecurityUtil.isLogin(session)){
         response.sendError(403); return;
     }
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
     String h_num=util.SecurityUtil.digitsOnly(request.getParameter("h_num"));
 	String g_num=util.SecurityUtil.digitsOnly(request.getParameter("g_num"));
     GradeDao dao = new GradeDao();

--- a/src/main/webapp/grade/insertgrade.jsp
+++ b/src/main/webapp/grade/insertgrade.jsp
@@ -7,8 +7,8 @@
   if(!util.SecurityUtil.isLogin(session)){
     response.sendError(403); return;
   }
-  // CSRF 토큰 검증(위조 요청 차단)
-  if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+  // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+  if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 %>
 <jsp:useBean id="dao" class="grade.model.GradeDao"/>
 <jsp:useBean id="dto" class="grade.model.GradeDto"/>

--- a/src/main/webapp/hugesoinfo/deletefavorite.jsp
+++ b/src/main/webapp/hugesoinfo/deletefavorite.jsp
@@ -6,8 +6,8 @@
 		if(!util.SecurityUtil.isLogin(session)){
 			response.sendError(403); return;
 		}
-		// CSRF 토큰 검증(위조 요청 차단)
-		if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+		// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+		if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 		//유지))삭제메서드 수정
     String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
 		String h_num=request.getParameter("h_num");

--- a/src/main/webapp/hugesoinfo/hugesoaddaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoaddaction.jsp
@@ -31,7 +31,7 @@
 		multi = new MultipartRequest(request, uploadPath, uploadSize, "utf-8", new DefaultFileRenamePolicy());
 
 		//CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-		if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+		if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
 			<script type="text/javascript">
 				alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
@@ -13,8 +13,8 @@
 	if(!util.SecurityUtil.isAdmin(session)){
 		response.sendRedirect("../index.jsp?main=hugesoinfo/hugesolist.jsp"); return;
 	}
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 	String h_num=request.getParameter("h_num");
 	String uploadPath = getServletContext().getRealPath("/hugesosave");
 	

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -242,7 +242,7 @@ $(function(){
 		    }
 		    
 		    $.ajax({
-		        type: "get", 
+		        type: "post",
 		        url: "grade/insertgrade.jsp",
 		        dataType: "html",
 		        data: {"h_num": $("#h_num").val(),  
@@ -1269,7 +1269,7 @@ marker.setMap(map);
 
 </div>
 <button type="button" onclick="location.href='index.jsp?main=hugesoinfo/hugesoupdateform.jsp?h_num=<%=h_num %>'" >수정</button> 
-<button type="button" onclick="location.href='hugesoinfo/hugesodeleteaction.jsp?h_num=<%=h_num %>&_csrf=<%=util.SecurityUtil.csrfToken(session)%>'">삭제</button>
+<button type="button" onclick="postNav('hugesoinfo/hugesodeleteaction.jsp', {h_num:'<%=h_num %>'})">삭제</button>
 </div>
 
 </div>

--- a/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
@@ -34,7 +34,7 @@
 		multi = new MultipartRequest(request, uploadPath, uploadSize, "utf-8", new DefaultFileRenamePolicy());
 
 		//CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-		if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+		if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
 			<script type="text/javascript">
 				alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/hugesoinfo/insertfavorite.jsp
+++ b/src/main/webapp/hugesoinfo/insertfavorite.jsp
@@ -9,8 +9,8 @@
    if(!util.SecurityUtil.isLogin(session)){
       response.sendError(403); return;
    }
-   // CSRF 토큰 검증(위조 요청 차단)
-   if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+   // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+   if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
    String h_num=request.getParameter("h_num");
    String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
 

--- a/src/main/webapp/hugesoinfo/updateh_grade.jsp
+++ b/src/main/webapp/hugesoinfo/updateh_grade.jsp
@@ -10,8 +10,8 @@
 	if(!util.SecurityUtil.isLogin(session)){
 		response.sendError(403); return;
 	}
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 	// 위변조 방어: 클라이언트가 보낸 h_grade/h_gradecount를 신뢰하지 않고
 	// grade 테이블에서 평균/개수를 서버에서 재계산한다(메인 "이달의 휴게소" 랭킹 조작 차단).
 	String h_num=util.SecurityUtil.digitsOnly(request.getParameter("h_num"));

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -95,6 +95,26 @@
         options.data = "_csrf=" + encodeURIComponent(_csrf);
       }
     });
+
+    // 링크형 상태변경(삭제 등)을 GET이 아닌 POST로 전송하기 위한 헬퍼.
+    // 숨김 폼을 만들어 _csrf와 파라미터를 함께 POST 제출한다.
+    window.postNav = function(url, params){
+      var f = document.createElement("form");
+      f.method = "post";
+      f.action = url;
+      params = params || {};
+      if(!("_csrf" in params)){ params._csrf = _csrf; }
+      for(var k in params){
+        if(!Object.prototype.hasOwnProperty.call(params, k)){ continue; }
+        var i = document.createElement("input");
+        i.type = "hidden";
+        i.name = k;
+        i.value = params[k];
+        f.appendChild(i);
+      }
+      document.body.appendChild(f);
+      f.submit();
+    };
   })();
   </script>
 

--- a/src/main/webapp/member/gaipaction.jsp
+++ b/src/main/webapp/member/gaipaction.jsp
@@ -14,8 +14,8 @@
 <%
 request.setCharacterEncoding("utf-8");
 
-// CSRF 토큰 검증(위조 요청 차단)
-if(!SecurityUtil.checkCsrf(request)){
+// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(request)){
 %>
 	<script type="text/javascript">
 		alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/member/passResetaction.jsp
+++ b/src/main/webapp/member/passResetaction.jsp
@@ -5,8 +5,8 @@
 <%
 request.setCharacterEncoding("utf-8");
 
-// CSRF 토큰 검증(위조 요청 차단)
-if(!SecurityUtil.checkCsrf(request)){
+// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(request)){
 %>
 <script type="text/javascript">alert("요청이 유효하지 않습니다."); history.back();</script>
 <%

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -239,7 +239,7 @@ font-size: 14px;
 				  //console.log(n);
 				  
 				  //삭제파일로 전송
-				  location.href="mypage/deleteadminevent.jsp?nums="+n+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+				  postNav("mypage/deleteadminevent.jsp", {nums:n});
 				  }
 			  }
 		  })

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -239,7 +239,7 @@ font-size: 14px;
 				  //console.log(n);
 				  
 				  //삭제파일로 전송
-				  location.href="mypage/deleteadminnotice.jsp?nums="+n+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+				  postNav("mypage/deleteadminnotice.jsp", {nums:n});
 				  }
 			  }
 		  })

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -238,7 +238,7 @@ font-size: 14px;
 				  
 				  
 				  //삭제파일로 전송
-				  location.href="mypage/deleteadminqna.jsp?nums="+n+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+				  postNav("mypage/deleteadminqna.jsp", {nums:n});
 				  }
 			  }
 		  })

--- a/src/main/webapp/mypage/deleteaction.jsp
+++ b/src/main/webapp/mypage/deleteaction.jsp
@@ -22,8 +22,8 @@
 		return;
 	}
 
-	// CSRF 토큰 검증(폼의 _csrf vs 세션 토큰)
-	if(!util.SecurityUtil.checkCsrf(request)){
+	// 상태변경은 POST + CSRF 토큰 검증(폼의 _csrf vs 세션 토큰)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
 		response.sendError(403);
 		return;
 	}

--- a/src/main/webapp/mypage/deleteadminevent.jsp
+++ b/src/main/webapp/mypage/deleteadminevent.jsp
@@ -16,8 +16,8 @@
 	if(!util.SecurityUtil.isAdmin(session)){
 		response.sendRedirect("../index.jsp"); return;
 	}
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 	//nums를 읽기
 	String nums=request.getParameter("nums");
 	//,로 분리해서 배열선언

--- a/src/main/webapp/mypage/deleteadminnotice.jsp
+++ b/src/main/webapp/mypage/deleteadminnotice.jsp
@@ -13,8 +13,8 @@
 	if(!util.SecurityUtil.isAdmin(session)){
 		response.sendRedirect("../index.jsp"); return;
 	}
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 	//nums를 읽기
 	String nums=request.getParameter("nums");
 	//,로 분리해서 배열선언

--- a/src/main/webapp/mypage/deleteadminqna.jsp
+++ b/src/main/webapp/mypage/deleteadminqna.jsp
@@ -16,8 +16,8 @@
     if(!util.SecurityUtil.isAdmin(session)){
         response.sendRedirect("../index.jsp"); return;
     }
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
     // nums를 읽기
     String nums = request.getParameter("nums");
     // 쉼표로 구분된 각 숫자 쌍을 분리

--- a/src/main/webapp/mypage/deleteqna.jsp
+++ b/src/main/webapp/mypage/deleteqna.jsp
@@ -16,8 +16,8 @@
 	if(!util.SecurityUtil.isLogin(session)){
 		response.sendRedirect("../index.jsp?main=member/loginform.jsp"); return;
 	}
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 	//nums를 읽기
 	String nums=request.getParameter("nums");
 	//,로 분리해서 배열선언

--- a/src/main/webapp/mypage/deletereview.jsp
+++ b/src/main/webapp/mypage/deletereview.jsp
@@ -13,8 +13,8 @@
 	if(!util.SecurityUtil.isLogin(session)){
 		response.sendRedirect("../index.jsp?main=member/loginform.jsp"); return;
 	}
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 	//nums를 읽기
 	String nums=request.getParameter("nums");
 	//,로 분리해서 배열선언

--- a/src/main/webapp/mypage/favdelete.jsp
+++ b/src/main/webapp/mypage/favdelete.jsp
@@ -6,8 +6,8 @@
 if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
-// CSRF 토큰 검증(위조 요청 차단)
-if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 String f_num=util.SecurityUtil.digitsOnly(request.getParameter("f_num"));
 MemInfoDao dao=new MemInfoDao();
 // IDOR 방어: m_num을 세션 사용자로부터 도출해 본인 소유분만 삭제

--- a/src/main/webapp/mypage/favlist.jsp
+++ b/src/main/webapp/mypage/favlist.jsp
@@ -86,7 +86,7 @@
 	
 	function delfav(f_num){
 		$.ajax({
-			type:"get",
+			type:"post",
 			url:"mypage/favdelete.jsp",
 			dataType:"html",
 			data:{"f_num":f_num},

--- a/src/main/webapp/mypage/memberdelete.jsp
+++ b/src/main/webapp/mypage/memberdelete.jsp
@@ -6,8 +6,8 @@
 if(!util.SecurityUtil.isAdmin(session)){
 	response.sendRedirect("../index.jsp"); return;
 }
-// CSRF 토큰 검증(위조 요청 차단)
-if(!util.SecurityUtil.checkCsrf(request)){
+// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
 	response.sendError(403); return;
 }
 String m_num=request.getParameter("m_num");

--- a/src/main/webapp/mypage/memberlist.jsp
+++ b/src/main/webapp/mypage/memberlist.jsp
@@ -137,7 +137,7 @@ $(function(){
 
 function delemem(m_num){
    if(confirm("정말 강퇴하시겠습니까?")){
-      location.href="mypage/memberdelete.jsp?m_num="+m_num+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+      postNav("mypage/memberdelete.jsp", {m_num:m_num});
    }
 }
 </script>

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -235,7 +235,7 @@ font-size: 14px;
               //console.log(n);
               
               //삭제파일로 전송
-              location.href="mypage/deleteqna.jsp?nums="+n+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+              postNav("mypage/deleteqna.jsp", {nums:n});
               }
            }
         })

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -238,7 +238,7 @@ div.img-container{
 				  //console.log(n);
 				  
 				  //삭제파일로 전송
-				  location.href="mypage/deletereview.jsp?nums="+n+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+				  postNav("mypage/deletereview.jsp", {nums:n});
 				  }
 			  }
 		  })

--- a/src/main/webapp/mypage/updateaction.jsp
+++ b/src/main/webapp/mypage/updateaction.jsp
@@ -16,8 +16,8 @@
 <%
 	request.setCharacterEncoding("utf-8");
 
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!SecurityUtil.checkCsrf(request)){
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(request)){
 %>
 	<script type="text/javascript">
 		alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/noticeboard/noticeAction.jsp
+++ b/src/main/webapp/noticeboard/noticeAction.jsp
@@ -41,7 +41,7 @@
     	multi = new MultipartRequest(request, uploadPath, uploadSize, "utf-8", new DefaultFileRenamePolicy());
 
     	//CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-    	if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+    	if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
     		<script type="text/javascript">
     			alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/noticeboard/noticeChu.jsp
+++ b/src/main/webapp/noticeboard/noticeChu.jsp
@@ -4,9 +4,16 @@
     pageEncoding="UTF-8"%>
 
     <%
+    // 상태변경(추천수 +1)이므로 POST + 로그인 + CSRF를 강제한다.
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.isLogin(session)
+          || !util.SecurityUtil.checkCsrf(request)){
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        return;
+    }
+
     //num 읽기
-    String n_num = request.getParameter("n_num");
-    
+    String n_num = util.SecurityUtil.digitsOnly(request.getParameter("n_num"));
+
     NoticeDao dao = new NoticeDao();
     dao.updateNoticeChu(n_num);
     

--- a/src/main/webapp/noticeboard/noticeDelete.jsp
+++ b/src/main/webapp/noticeboard/noticeDelete.jsp
@@ -18,8 +18,8 @@
   if(!util.SecurityUtil.isAdmin(session)){
     response.sendRedirect("../index.jsp?main=noticeboard/noticeList.jsp"); return;
   }
-  // CSRF 토큰 검증(위조 요청 차단)
-  if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+  // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+  if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
   String n_num=request.getParameter("n_num");
   String currentPage=request.getParameter("currentPage");
 

--- a/src/main/webapp/noticeboard/noticeDetail.jsp
+++ b/src/main/webapp/noticeboard/noticeDetail.jsp
@@ -65,7 +65,7 @@
 		  
 		  
 		  $.ajax ({
-			type : "get",
+			type : "post",
 			dataType : "json",
 			url : "noticeboard/noticeChu.jsp",
 			data : {"n_num":n_num},
@@ -92,7 +92,7 @@
 	  var ans=confirm("삭제하려면 [확인]을 눌러주세요");
 	   
 	   if(ans){
-		   location.href='noticeboard/noticeDelete.jsp?n_num='+n_num+"&currentPage="+currentPage+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+		   postNav('noticeboard/noticeDelete.jsp', {n_num:n_num, currentPage:currentPage});
 	   } 
   }
  

--- a/src/main/webapp/noticeboard/noticeUpdateAction.jsp
+++ b/src/main/webapp/noticeboard/noticeUpdateAction.jsp
@@ -35,7 +35,7 @@
   multi=new MultipartRequest(request,realPath,uploadSize,"utf-8",new DefaultFileRenamePolicy());
 
        //CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-       if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+       if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
        <script type="text/javascript">
            alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/qaanswer/qaAnswerDelete.jsp
+++ b/src/main/webapp/qaanswer/qaAnswerDelete.jsp
@@ -9,8 +9,8 @@
   if(!util.SecurityUtil.isAdmin(session)){
       response.sendError(403); return;
   }
-  // CSRF 토큰 검증(위조 요청 차단)
-  if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+  // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+  if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
   String q_num=request.getParameter("q_num");
   String qa_num = request.getParameter("qa_num");
   

--- a/src/main/webapp/qaanswer/qaAnswerInsertAction.jsp
+++ b/src/main/webapp/qaanswer/qaAnswerInsertAction.jsp
@@ -10,8 +10,8 @@
     if(!util.SecurityUtil.isAdmin(session)){
         response.sendError(403); return;
     }
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
     //로그인 세션얻기
 	String loginok=(String)session.getAttribute("loginok");
 	//아이디 얻기

--- a/src/main/webapp/qaanswer/qaAnswerUpdateAction.jsp
+++ b/src/main/webapp/qaanswer/qaAnswerUpdateAction.jsp
@@ -9,8 +9,8 @@
     if(!util.SecurityUtil.isAdmin(session)){
         response.sendError(403); return;
     }
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
     //로그인 세션얻기
 	String loginok=(String)session.getAttribute("loginok");
 	//아이디 얻기

--- a/src/main/webapp/qaboard/qaAction.jsp
+++ b/src/main/webapp/qaboard/qaAction.jsp
@@ -23,8 +23,8 @@
   <%
     request.setCharacterEncoding("utf-8");
 
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
 %>
     <script type="text/javascript">alert("요청이 유효하지 않습니다."); history.back();</script>
 <%

--- a/src/main/webapp/qaboard/qaDelete.jsp
+++ b/src/main/webapp/qaboard/qaDelete.jsp
@@ -17,8 +17,8 @@
     String q_num = request.getParameter("q_num");
     String currentPage = request.getParameter("currentPage");
 
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 
     QaDao dao = new QaDao();
 

--- a/src/main/webapp/qaboard/qaDetail.jsp
+++ b/src/main/webapp/qaboard/qaDetail.jsp
@@ -93,7 +93,7 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 			 
 			 $.ajax({
 				
-				 type : "get",
+				 type : "post",
 				 url : "qaanswer/qaAnswerInsertAction.jsp",
 				 datatype : "html",
 				 data : {"q_num":q_num,"qa_content":qa_content},
@@ -126,7 +126,7 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 			   if(ans){
 				   $.ajax({
 					   
-					   type:"get",
+					   type:"post",
 					   url:"qaanswer/qaAnswerDelete.jsp",
 					   dataType:"html",
 					   data:{"q_num":q_num, "qa_num":qa_num},
@@ -175,7 +175,7 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 	    	//alert(q_num+","+qa_num+","+qa_content);
 	    	
 	    	$.ajax({
-	    		type : "get",
+	    		type : "post",
 	    		url : "qaanswer/qaAnswerUpdateAction.jsp",
 	    		dataType : "html",
 	    		data : {"q_num":q_num, "qa_num":qa_num,"qa_content":qa_content},
@@ -197,7 +197,7 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
  	  var ans=confirm("삭제하려면 [확인]을 눌러주세요");
  	   
  	   if(ans){
- 		   location.href='qaboard/qaDelete.jsp?q_num='+q_num+"&currentPage="+currentPage+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+ 		   postNav('qaboard/qaDelete.jsp', {q_num:q_num, currentPage:currentPage});
  	   } 
    }
  

--- a/src/main/webapp/qaboard/qaUpdateAction.jsp
+++ b/src/main/webapp/qaboard/qaUpdateAction.jsp
@@ -16,8 +16,8 @@
   <%
     request.setCharacterEncoding("utf-8");
 
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
 %>
     <script type="text/javascript">alert("요청이 유효하지 않습니다."); history.back();</script>
 <%

--- a/src/main/webapp/reviewboard/reviewAction.jsp
+++ b/src/main/webapp/reviewboard/reviewAction.jsp
@@ -42,7 +42,7 @@
     	multi = new MultipartRequest(request,uploadPath,uploadSize,"utf-8",new DefaultFileRenamePolicy());
 
     	//CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-    	if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+    	if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
     		<script type="text/javascript">
     			alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/reviewboard/reviewChu.jsp
+++ b/src/main/webapp/reviewboard/reviewChu.jsp
@@ -4,9 +4,16 @@
     pageEncoding="UTF-8"%>
 
     <%
+    // 상태변경(추천수 +1)이므로 POST + 로그인 + CSRF를 강제한다.
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.isLogin(session)
+          || !util.SecurityUtil.checkCsrf(request)){
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        return;
+    }
+
     //num 읽기
-    String r_num = request.getParameter("r_num");
-    
+    String r_num = util.SecurityUtil.digitsOnly(request.getParameter("r_num"));
+
     ReviewDao dao = new ReviewDao();
     dao.updateReviewChu(r_num);
     

--- a/src/main/webapp/reviewboard/reviewDelete.jsp
+++ b/src/main/webapp/reviewboard/reviewDelete.jsp
@@ -21,8 +21,8 @@
     String r_num = request.getParameter("r_num");
     String currentPage = request.getParameter("currentPage");
 
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 
     //db로 부터 저장된 이미지명 얻기
     ReviewDao dao = new ReviewDao();

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -112,7 +112,7 @@
 		  
 		  
 		  $.ajax ({
-			type : "get",
+			type : "post",
 			dataType : "json",
 			url : "reviewboard/reviewChu.jsp",
 			data : {"r_num":r_num},
@@ -146,7 +146,7 @@
     	var ans=confirm("삭제하려면 [확인]을 눌러주세요");
  	   
  	    if(ans){
- 		   location.href='reviewboard/reviewDelete.jsp?r_num='+r_num+"&currentPage="+currentPage+"&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+ 		   postNav('reviewboard/reviewDelete.jsp', {r_num:r_num, currentPage:currentPage});
  	   } 
     })
     

--- a/src/main/webapp/reviewboard/reviewUpdateAction.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateAction.jsp
@@ -34,7 +34,7 @@
 		multi = new MultipartRequest(request, realPath, uploadSize, "utf-8", new DefaultFileRenamePolicy());
 
 			//CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-			if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+			if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
 			<script type="text/javascript">
 				alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/shop/shopAction.jsp
+++ b/src/main/webapp/shop/shopAction.jsp
@@ -41,7 +41,7 @@
     	multi = new MultipartRequest(request, uploadPath, uploadSize, "utf-8", new DefaultFileRenamePolicy());
 
     	//CSRF 토큰 검증(멀티파트라 multi에서 _csrf를 읽어 검증)
-    	if(!SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
+    	if(!SecurityUtil.isPost(request) || !SecurityUtil.checkCsrf(session, multi.getParameter("_csrf"))){
 %>
     		<script type="text/javascript">
     			alert("요청이 유효하지 않습니다.");

--- a/src/main/webapp/shop/shopAllDelete.jsp
+++ b/src/main/webapp/shop/shopAllDelete.jsp
@@ -17,8 +17,8 @@
 	if(!util.SecurityUtil.isAdmin(session)){
 		response.sendRedirect("../index.jsp?main=shop/shopList.jsp"); return;
 	}
-	// CSRF 토큰 검증(위조 요청 차단)
-	if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+	// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 	//nums를 읽기
 	String s_nums=request.getParameter("s_nums");
 	//,로 분리해서 배열선언

--- a/src/main/webapp/shop/shopDelete.jsp
+++ b/src/main/webapp/shop/shopDelete.jsp
@@ -18,8 +18,8 @@
     if(!util.SecurityUtil.isAdmin(session)){
       response.sendRedirect("../index.jsp?main=shop/shopList.jsp"); return;
     }
-    // CSRF 토큰 검증(위조 요청 차단)
-    if(!util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
+    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
+    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
     //db삭제뿐 아니라 업로드된 파일도 삭제하기
     String s_num = request.getParameter("s_num");
     String currentPage = request.getParameter("currentPage");

--- a/src/main/webapp/shop/shopList.jsp
+++ b/src/main/webapp/shop/shopList.jsp
@@ -148,7 +148,7 @@ $(function(){
                 console.log(sNumsParam);
 
                 // 삭제파일로 전송
-                location.href = "shop/shopAllDelete.jsp?s_nums=" + sNumsParam + "&_csrf=<%=util.SecurityUtil.csrfToken(session)%>";
+                postNav("shop/shopAllDelete.jsp", {s_nums: sNumsParam});
             }
         }
     });


### PR DESCRIPTION
## 개요
9차 CSRF 일괄적용을 신규 세션에서 **코드 레벨로 재검증**한 결과를 반영한 10차 보안 수정입니다. 누락 경로 2건을 보강하고, 사용자 결정에 따라 상태변경의 **GET→POST 전환**을 함께 수행했습니다.

## 발견·수정한 실질 취약점
| 심각도 | 내용 | 조치 |
|---|---|---|
| **Medium** | 추천(좋아요) 엔드포인트 `eventChu`/`noticeChu`/`reviewChu` — `updateXxxChu`(추천수 +1, 상태변경)인데 CSRF 검증도 로그인/권한 가드도 **전혀 없음**. 단순 GET(`<img src>` 등)으로 위조 가능(9차 누락 형제 경로). | `isPost`+`isLogin`+`checkCsrf` 가드 추가, 소비처 AJAX `get→post`, eventChu 순수 JSON 정리 |
| **Low** | `eventboard/eventList.jsp` 작성자명(`name`) raw 출력 — 형제 `noticeList.jsp`는 이미 `escapeHtml` 적용 | `escapeHtml(name)` 적용 |

## 하드닝 — 상태변경 GET→POST 전면 전환
- `util/SecurityUtil.isPost(HttpServletRequest)` 헬퍼 추가
- `index.jsp`: 전역 `ajaxPrefilter`와 같은 최종 스크립트 블록에 `window.postNav(url, params)` 헬퍼 추가(숨김 폼 POST 제출, `_csrf` 자동 첨부)
- AJAX `get→post` 전환(상태변경): `foodcartdelete`, `cartalldelete`, `qaAnswerInsert/Delete/Update`, `insertgrade`, `favdelete`
- `location.href` 삭제 링크 → `postNav` 전환: `notice/event/review/qaDelete`, `hugesodeleteaction`, `shopAllDelete`, `deleteadminqna/event/notice`, `deleteqna`, `deletereview`, `memberdelete`(관리자 회원 강퇴 — GET-링크였음)
- 모든 상태변경 액션 진입부에 `isPost` 가드 일관 보강(일반 POST·멀티파트 포함). 멀티파트는 `checkCsrf(session, multi.getParameter("_csrf"))`와 함께 적용

## 검증
- `javac`로 `src/main/java` 전체 컴파일 통과(`-encoding UTF-8`, Tomcat lib + WEB-INF/lib)
- 정적 점검: (1) 모든 상태변경 액션 `isPost`+CSRF 가드 적용, (2) 상태변경 소비처 `type:get` 잔존 0건(읽기 조회만 GET 유지), (3) 삭제 `location.href` 잔존 0건(전부 `postNav`)
- ⚠️ 이 환경은 Tomcat 런타임 회귀 불가 → 코드 레벨 + grep 검증으로 대체

## 재확인 후 안전 판정(재보고 안 함)
IDOR(세션 식별자 강제·소유자 WHERE), SQLi(전 DAO `?` 바인딩), 업로드(확장자+MIME+매직바이트·경로 이중정규화), 인증/세션(changeSessionId·BCrypt·m_role 미주입), 설정(error-page·SameSite·자격증명 외부화) 모두 코드로 양호 확인.

## 잔존 후속 과제(이번 범위 외)
- `printStackTrace` 로거 미전환(Low)
- 비밀번호 재설정 지식기반 검증 → 이메일/SMS 일회성 토큰 권장
- `foodgradesort` 음식 이미지 옛 경로(`image/food/...`) 출력 정합성

🤖 Generated with [Claude Code](https://claude.com/claude-code)
