### PR TITLE
보안 취약점 수정 11차: 인증 흐름 엔드포인트 isPost+CSRF 하드닝

### DIFF
--- a/src/main/webapp/layout/title.jsp
+++ b/src/main/webapp/layout/title.jsp
@@ -155,8 +155,9 @@ String myid = (String) session.getAttribute("myid");
             <%
             } else {
             %>
+            <%-- 로그아웃 CSRF 차단: GET 링크 대신 postNav로 POST+_csrf 제출 --%>
             <li style="padding-left: 735px;"><a
-               href="member/logoutaction.jsp">로그아웃</a></li>
+               href="#" onclick="postNav('member/logoutaction.jsp',{}); return false;">로그아웃</a></li>
             <%
             if (loginok != null && "ADMIN".equals((String)session.getAttribute("role"))) {
             %>

--- a/src/main/webapp/member/loginaction.jsp
+++ b/src/main/webapp/member/loginaction.jsp
@@ -12,6 +12,10 @@
 </head>
 <body>
 <%
+// 로그인 CSRF 차단: POST + 세션 CSRF 토큰 검증 후에만 인증 처리
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+	response.sendError(403); return;
+}
 String id=request.getParameter("m_id");
 String pass=request.getParameter("m_pass");
 String cbsave=request.getParameter("cbsave");

--- a/src/main/webapp/member/loginform.jsp
+++ b/src/main/webapp/member/loginform.jsp
@@ -62,6 +62,8 @@ onclick="location.href='../index.jsp'"></div>
 <div style="width: 500px;  margin: 0 auto; margin-top: 50px; margin-bottom:100px; border: 1px solid #ccc; border-radius: 10px;" >
 	
 	<form style="margin:50px;" action="loginaction.jsp" method="post">
+		<%-- CSRF 토큰: 로그인 CSRF(피해자를 공격자 계정으로 강제 로그인) 차단 --%>
+		<input type="hidden" name="_csrf" value="<%=util.SecurityUtil.csrfToken(session)%>">
 
 		<table class="table table-bordered" >
 		<caption align="top" style="font-size: 1.2em;">아이디 로그인</caption>

--- a/src/main/webapp/member/logoutaction.jsp
+++ b/src/main/webapp/member/logoutaction.jsp
@@ -11,6 +11,10 @@
 </head>
 <body>
 <%
+// 로그아웃 CSRF 차단: POST + CSRF 토큰 검증을 통과해야만 세션을 무효화한다.
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+	response.sendError(403); return;
+}
 //세션 전체 무효화(loginok뿐 아니라 myid/role/saveok/CSRF 토큰까지 제거)
 session.invalidate();
 response.sendRedirect("../index.jsp");

--- a/src/main/webapp/member/passSearchaction.jsp
+++ b/src/main/webapp/member/passSearchaction.jsp
@@ -4,6 +4,10 @@
     pageEncoding="UTF-8"%>
 <%
 request.setCharacterEncoding("utf-8");
+// 무인증 존재확인 오라클이므로 GET 프리패치·교차사이트 호출을 차단(POST+CSRF 강제)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+	response.sendError(403); return;
+}
 String m_name=request.getParameter("m_name");
 String m_id=request.getParameter("m_id");
 String m_hp2=request.getParameter("m_hp2");

--- a/src/main/webapp/mypage/updatepassaction.jsp
+++ b/src/main/webapp/mypage/updatepassaction.jsp
@@ -11,6 +11,11 @@
 	if(!util.SecurityUtil.isLogin(session)){
 		response.sendError(403); return;
 	}
+	// 상태변경 아님(조회 오라클)이나 다른 액션과 동일하게 POST+CSRF 강제
+	// (GET 프리패치·교차사이트 호출로 자격증명 확인 오라클이 악용되는 것 차단)
+	if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+		response.sendError(403); return;
+	}
 	// 검증 대상 ID는 클라이언트 입력이 아닌 세션 사용자로 고정 (무차별 대입 방지)
 	String m_id=util.SecurityUtil.currentId(session);
 	String m_pass=request.getParameter("m_pass");


### PR DESCRIPTION
## 개요

10차(PR #71)에서 상태변경을 GET→POST 전면 전환하며 CSRF·접근제어를 일괄 적용했으나,
"DB 상태를 바꾸는 액션"이 아니라는 이유로 인증·검증 오라클 엔드포인트 4건이 누락됐다.
이번 11차는 나머지 ~60개 액션과 동일한 `isPost + checkCsrf` 가드를 이 4건에 적용해
일관성을 맞춘다. 모두 **Low 심각도 하드닝**이며, 신규 Critical/High/Medium 발견은 없다.

신규 리뷰에서 10차까지의 핵심 취약점(저장형/반사형/DOM XSS, IDOR, 접근제어, SQLi,
상태변경 CSRF)은 코드로 재검증한 결과 모두 양호함을 확인했다.

## 변경 사항

| 파일 | 조치 |
|---|---|
| `member/loginaction.jsp` | 진입부 `isPost+checkCsrf` 403 가드(인증 처리 전) — 로그인 CSRF 차단 |
| `member/loginform.jsp` | 로그인 폼에 hidden `_csrf` 추가 |
| `member/logoutaction.jsp` | `session.invalidate()` 전 `isPost+checkCsrf` 403 가드 — 로그아웃 CSRF 차단 |
| `layout/title.jsp` | 로그아웃 GET 링크 → `postNav('member/logoutaction.jsp',{})`(POST+_csrf 자동첨부) |
| `member/passSearchaction.jsp` | 무인증 존재확인 오라클에 `isPost+checkCsrf` 강제(소비처 이미 `type:"post"`라 무중단) |
| `mypage/updatepassaction.jsp` | 자기 비밀번호 확인 오라클에 `isPost+checkCsrf` 강제(기존 `isLogin`+`currentId` IDOR 방어 유지, 소비처 `type:"post"` 무중단) |

신규 헬퍼·신규 코드 없이 기존 패턴만 재사용: `SecurityUtil.isPost`/`checkCsrf`/`csrfToken`,
`index.jsp`의 `postNav`/`ajaxPrefilter`.

## 검증

- `src/main/java` 전체 `javac -encoding UTF-8` 클린 컴파일(exit 0).
- grep 정적 점검: 4개 액션 진입부 가드 존재, `loginform` hidden `_csrf` 존재,
  `title.jsp` 로그아웃 `postNav` 전환, `href="member/logoutaction.jsp"` 직접 GET 링크 0건.
- 소비처 회귀 없음: `passSearchform.jsp`/`updatepassform.jsp`는 `type:"post"` 유지(변경 없음).
- 런타임 한계: 이 환경은 Tomcat 기동 불가 → 실제 403/정상흐름은 코드·grep 정적 점검으로 대체.
  배포 환경 수동 확인 권장: ① 로그인/로그아웃/비번찾기/비번확인 정상 동작,
  ② 각 액션을 GET 또는 잘못된/누락 `_csrf`로 호출 시 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
