### PR TITLE
보안 취약점 수정 12차: 11차 누락 조회·검증 오라클에 isPost+CSRF 가드 보강

### DIFF
--- a/src/main/webapp/member/gaipform.jsp
+++ b/src/main/webapp/member/gaipform.jsp
@@ -72,7 +72,7 @@ $(function(){
 }
 		
 		$.ajax({
-			type:"get",
+			type:"post",
 			url:"idcheck.jsp",
 			dataType:"json",
 			data:{"id":id},
@@ -107,7 +107,7 @@ $(function(){
     }
 	 
 	 $.ajax({
-		 type:"get",
+		 type:"post",
 		 url:"nickcheck.jsp",
 		 dataType:"json",
 		 data:{"m_nick":nick},

--- a/src/main/webapp/member/idcheck.jsp
+++ b/src/main/webapp/member/idcheck.jsp
@@ -4,6 +4,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
+// 무인증 아이디 중복확인 오라클: GET 프리패치·교차사이트 호출 차단(POST+CSRF 강제, 11차와 동일 하드닝)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+    response.sendError(403); return;
+}
 String id=request.getParameter("id");
 MemInfoDao dao=new MemInfoDao();
 // 예약 아이디(admin 등)는 사용 불가 처리(이미 존재하는 것과 동일하게 1 반환)

--- a/src/main/webapp/member/idsearchaction_email.jsp
+++ b/src/main/webapp/member/idsearchaction_email.jsp
@@ -3,6 +3,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
+// 무인증 아이디찾기 오라클: GET 프리패치·교차사이트 호출 차단(POST+CSRF 강제, 11차와 동일 하드닝)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+    response.sendError(403); return;
+}
 String m_name=request.getParameter("m_name2");
 String m_email=request.getParameter("m_email2");
 

--- a/src/main/webapp/member/idsearchaction_hp.jsp
+++ b/src/main/webapp/member/idsearchaction_hp.jsp
@@ -3,6 +3,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
+// 무인증 아이디찾기 오라클: GET 프리패치·교차사이트 호출 차단(POST+CSRF 강제, 11차와 동일 하드닝)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+    response.sendError(403); return;
+}
 String m_name=request.getParameter("m_name");
 String m_hp2=request.getParameter("m_hp2");
 

--- a/src/main/webapp/member/nickcheck.jsp
+++ b/src/main/webapp/member/nickcheck.jsp
@@ -3,6 +3,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
+// 무인증 닉네임 중복확인 오라클: GET 프리패치·교차사이트 호출 차단(POST+CSRF 강제, 11차와 동일 하드닝)
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+    response.sendError(403); return;
+}
 String m_nick=request.getParameter("m_nick");
 MemInfoDao dao=new MemInfoDao();
 int nickcount=dao.nickcount(m_nick);

--- a/src/main/webapp/mypage/nickcheck.jsp
+++ b/src/main/webapp/mypage/nickcheck.jsp
@@ -3,9 +3,15 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
+// 로그인 필수(타인 닉네임 무인증 조회 차단) + POST+CSRF 강제(11차와 동일 하드닝)
+if(!util.SecurityUtil.isLogin(session)){ response.sendError(403); return; }
+if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
+    response.sendError(403); return;
+}
 String m_nick=request.getParameter("m_nick");
-String m_num=request.getParameter("m_num");
 MemInfoDao dao=new MemInfoDao();
+// m_num은 클라이언트 입력 대신 세션 사용자로 고정(임의 m_num으로 타인 닉네임 조회하는 IDOR 차단)
+String m_num=dao.getM_num(util.SecurityUtil.currentId(session));
 int count=dao.numPassCheck(m_num, m_nick);
 int nickcount=dao.nickcount(m_nick);
 String nickname=dao.getNick(m_num);

--- a/src/main/webapp/mypage/updateform.jsp
+++ b/src/main/webapp/mypage/updateform.jsp
@@ -72,7 +72,7 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 			var num = $("#m_num").val();
 			//alert(nickname+","+num);
 			$.ajax({
-				type : "get",
+				type : "post",
 				url : "mypage/nickcheck.jsp",
 				dataType : "json",
 				data : {


### PR DESCRIPTION
## 개요

신규 세션에서 시큐어 코드 리뷰를 재수행(1~11차 적용분을 코드로 직접 재검증)한 결과, **11차에서 누락된 동종 조회·검증 오라클 5건**을 발견해 보강한다. 11차는 "DB 상태변경이 아닌 인증·검증·조회 오라클"(login/logout/passSearch/updatepass)에 `isPost+checkCsrf`를 일괄 적용했으나, 같은 부류의 무인증(또는 약한 가드) 읽기 오라클 5건이 빠져 있었다.

> 읽기 전용 JSON 오라클이라 SOP상 교차출처 응답 읽기가 불가능해 CSRF 실익은 작다. 따라서 **모두 Low(11차와의 일관성·심층방어 하드닝)**이며, 열거(enumeration)·PII 노출 근본 차단은 아니다(이는 rate-limit/일회성 토큰 별건 후속과제).

## 재검증 결과 (이번 PR 변경 없음 — 정상 확인)

- **11차 4건(login/logout/passSearch/updatepass)** — `isPost+checkCsrf` 403 가드가 실제로 통과를 강제, `loginform.jsp` hidden `_csrf` 존재, `title.jsp` 로그아웃 `postNav` 전환·직접 GET 잔존 0건. 정상.
- **XSS·IDOR·SQLi·업로드·세션** 전수 점검 — list/detail/JSON/map/paging 사각지대까지 인코딩 일관, 상태변경 IDOR 방어 완비. 신규 취약점 없음.

## 변경 내용

### 서버측 가드 추가 (5건, 11차와 동일 패턴)

| 파일 | 동작 | 가드 |
|---|---|---|
| `member/idcheck.jsp` | 아이디 중복확인 | `isPost+checkCsrf` |
| `member/nickcheck.jsp` | 닉네임 중복확인 | `isPost+checkCsrf` |
| `member/idsearchaction_hp.jsp` | 아이디찾기 | `isPost+checkCsrf` |
| `member/idsearchaction_email.jsp` | 아이디찾기 | `isPost+checkCsrf` |
| `mypage/nickcheck.jsp` | 닉네임 확인 | `isLogin` + `isPost+checkCsrf` + IDOR 보강 |

`mypage/nickcheck.jsp`는 클라이언트가 보낸 `m_num`으로 임의 회원의 닉네임을 무인증 조회할 수 있던 경미한 정보노출(IDOR)이 있어, `m_num`을 클라이언트 입력 대신 세션 사용자(`getM_num(currentId(session))`)로 고정했다.

### 소비처 AJAX `get→post` 전환 (3건)

서버가 `isPost`를 강제하므로 GET 소비처를 POST로 전환한다. 전역 `ajaxPrefilter`가 `_csrf`를 자동 첨부하므로 `type`만 변경(`data` 무변경).

- `member/gaipform.jsp` — idcheck / nickcheck 호출
- `mypage/updateform.jsp` — mypage/nickcheck 호출

(`idsearchaction_hp/_email` 소비처는 이미 `type:"post"`라 무변경.)

## 검증

신규 Java 코드 없음(기존 `SecurityUtil.isPost/checkCsrf/isLogin/currentId`, `MemInfoDao.getM_num` 재사용). 정적 점검(grep):

1. 5개 액션 진입부에 `isPost+checkCsrf` 가드(DB 호출 이전) 확인
2. `mypage/nickcheck.jsp`에 `isLogin` + `getM_num(currentId(session))` 적용, `request.getParameter("m_num")` 잔존 0건
3. `gaipform.jsp`/`updateform.jsp`의 `type:"get"` 잔존 0건

> 한계: 이 환경은 Tomcat 기동 불가라 런타임 회귀는 코드 레벨로 대체. 기능 흐름상 회원가입 실시간 중복확인/아이디찾기/마이페이지 닉네임확인은 POST 전환 후에도 prefilter 토큰 첨부로 무중단 동작 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
