### PR TITLE
보안 취약점 수정 13차: 즐겨찾기 목록 저장형 XSS 출력 인코딩 보강

### DIFF
--- a/src/main/webapp/mypage/favlist.jsp
+++ b/src/main/webapp/mypage/favlist.jsp
@@ -142,10 +142,10 @@ List<HashMap<String,String>> list=dao.getFavlist(m_id);
 					<input type="checkbox" name="f_num" f_num=<%=map.get("f_num") %> class="f_num">
 				</td>
 				<td><a href="index.jsp?main=hugesoinfo/hugesodetail.jsp?h_num=<%=map.get("h_num") %>"
-				style="text-decoration: none;"><%=map.get("h_name") %></a></td>
-				<td><%=map.get("h_addr") %></td>
-				<td><%=map.get("h_pyeon") %></td>
-				<td><%=map.get("h_hp") %></td>
+				style="text-decoration: none;"><%=util.SecurityUtil.escapeHtml(map.get("h_name")) %></a></td>
+				<td><%=util.SecurityUtil.escapeHtml(map.get("h_addr")) %></td>
+				<td><%=util.SecurityUtil.escapeHtml(map.get("h_pyeon")) %></td>
+				<td><%=util.SecurityUtil.escapeHtml(map.get("h_hp")) %></td>
 			
 			</tr>	
 		<%}


### PR DESCRIPTION
## 개요
보안 코드 리뷰 13차. 12차(PR #73)까지의 수정분을 코드로 재검증한 결과 누락 없이 정상 적용됨을 확인했고, 재검증 중 발견한 **신규 누락 1건**(즐겨찾기 목록 저장형 XSS)을 수정합니다.

## 발견 및 수정 (확정 1건)
| 심각도 | 카테고리 | 위치 | 내용 |
|--------|----------|------|------|
| Medium | 저장형 XSS (출력 인코딩 누락) | `src/main/webapp/mypage/favlist.jsp:145-148` | 휴게소 즐겨찾기 목록의 `h_name`·`h_addr`·`h_pyeon`·`h_hp`를 `escapeHtml` 없이 raw 출력 |

- 동일 필드(`h_name`/`h_addr`/`h_hp`)는 이미 `hugesopaging.jsp`(8·9차)에서 `escapeHtml`로 보호 중이었으나 `favlist.jsp`만 누락된 **"detail/paging은 인코딩, list는 누락"** 사각지대였습니다.
- 4개 표시 필드를 `util.SecurityUtil.escapeHtml(...)`로 래핑(기존 헬퍼 재사용, 신규 코드 없음). 동작·레이아웃 불변.
- 데이터 출처가 관리자 전용 입력(`hugeso` 테이블, `hugesoaddaction`/`updateaction`은 `isAdmin` 가드)이라 실익은 제한적이나, 전 출력 인코딩 정책(CLAUDE.md) 및 기존 라운드와의 정합성을 맞췄습니다.

## 변경 파일
- `src/main/webapp/mypage/favlist.jsp` (4행)

## 재검증 결과 (이번 변경 외)
- **12차 변경분 정상 확인**: 5개 오라클(`member/idcheck`·`nickcheck`·`idsearchaction_hp`·`idsearchaction_email`, `mypage/nickcheck`) 모두 진입부 `isPost+checkCsrf` 통과 필수(GET/토큰누락 시 403). `mypage/nickcheck.jsp`는 `isLogin` 추가 가드 + `m_num`을 세션(`getM_num(currentId(session))`)으로 고정(클라이언트 `m_num` 신뢰 제거, 잔존 0건). 소비처 AJAX는 모두 `type:"post"` 전환(보안 관련 `type:"get"` 잔존 0건).
- **오탐 정정(수정 불필요)**: `foodgrade/updatef_grade.jsp`의 "권한 미흡" 의심은 비취약 — 기록값 `f_grade`는 서버 재계산 평균(`fgdao.avgFoodGrade`)이며 `FoodDao.updateF_grade`는 그 값만 기록하므로 위변조 불가(`updateh_grade`와 동일한 안전 패턴).

## 검증 방법
이 환경은 Tomcat 기동 불가 → 코드 레벨 + grep 정적 점검으로 검증(한계 명시).
- `<%= map.get("h_name|h_addr|h_pyeon|h_hp") %>` raw 출력 패턴 webapp 전역 **잔존 0건** 확인.
- `SecurityUtil.escapeHtml(String)`은 `null` 입력 시 `""` 반환(null 안전), `map`이 `HashMap<String,String>`이라 캐스팅 불필요.
- 자바 소스 변경 없음 → 컴파일 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
