### PR TITLE
휴게소 도메인 리팩터: DAO mapRow 추출·조회 메서드 select* 통일·죽은 코드 제거

### DIFF
--- a/src/main/java/hugesoinfo/model/HugesoInfoDao.java
+++ b/src/main/java/hugesoinfo/model/HugesoInfoDao.java
@@ -38,7 +38,7 @@ public class HugesoInfoDao {
 	}
 
 	//전체데이터 List에 담아서 리턴하는 메서드
-	public List<HugesoInfoDto> getAllDatas(){
+	public List<HugesoInfoDto> selectAllDatas(){
 		List<HugesoInfoDto> list = new Vector<HugesoInfoDto>();
 
 		Connection conn = db.getConnection();
@@ -65,7 +65,7 @@ public class HugesoInfoDao {
 
 	//페이징..1.전체갯수반환   2.부분조회(startnum부터 perpage갯수만큼 반환)
 	//1.전체갯수반환
-	public int getTotalCount() {
+	public int selectTotalCount() {
 		int total=0;
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
@@ -89,7 +89,7 @@ public class HugesoInfoDao {
 	}
 
 	//2.부분조회(startnum부터 perpage갯수만큼 반환)
-	public List<HugesoInfoDto> getPagingList(int startNum,int perPage) {
+	public List<HugesoInfoDto> selectPagingList(int startNum,int perPage) {
 		List<HugesoInfoDto> list=new ArrayList<HugesoInfoDto>();
 
 		Connection conn=db.getConnection();
@@ -120,7 +120,7 @@ public class HugesoInfoDao {
 	}
 
 	//h_num에 해당하는 휴게소 데이터 리턴 (hugesodetail.jsp)
-	public HugesoInfoDto getData(String h_num) {
+	public HugesoInfoDto selectData(String h_num) {
 		HugesoInfoDto dto = new HugesoInfoDto();
 
 		Connection conn = db.getConnection();
@@ -217,7 +217,7 @@ public class HugesoInfoDao {
 	}
 
 	//유지))휴게소 이름하고 넘버가 필요해서 작성했어요. 나중에 수정되거나 삭제될 가능성 있음. foodcourt/choice에서 사용함
-	public List<HugesoInfoDto> getH_numH_name(){
+	public List<HugesoInfoDto> selectH_numH_name(){
 		List<HugesoInfoDto> list = new Vector<HugesoInfoDto>();
 
 		Connection conn = db.getConnection();
@@ -246,7 +246,7 @@ public class HugesoInfoDao {
 	}
 
 	// 검색 결과 총 갯수
-	public int getSearchTotalCount(String h_name) {
+	public int selectSearchTotalCount(String h_name) {
 		int total=0;
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
@@ -271,7 +271,7 @@ public class HugesoInfoDao {
 	}
 
 	//검색결과 부분조회
-	public List<HugesoInfoDto> getSearchPagingList(String h_name,int startNum,int perPage) {
+	public List<HugesoInfoDto> selectSearchPagingList(String h_name,int startNum,int perPage) {
 		List<HugesoInfoDto> list=new ArrayList<HugesoInfoDto>();
 
 		Connection conn=db.getConnection();
@@ -380,7 +380,7 @@ public class HugesoInfoDao {
 	}
 
 	//승경_메인화면에 휴게소 평점 순위대로 가져오기 위해 생성
-	public List<HugesoInfoDto> getAllGrade(){
+	public List<HugesoInfoDto> selectAllGrade(){
 		List<HugesoInfoDto> gradelist = new ArrayList<HugesoInfoDto>();
 
 		Connection conn = db.getConnection();

--- a/src/main/java/hugesoinfo/model/HugesoInfoDao.java
+++ b/src/main/java/hugesoinfo/model/HugesoInfoDao.java
@@ -13,389 +13,302 @@ import mysql.db.DbConnect;
 
 
 public class HugesoInfoDao {
-	
-	DbConnect db=new DbConnect();
-	
-	
+
+	private DbConnect db = new DbConnect();
+
+	//공통: ResultSet 한 행을 HugesoInfoDto로 매핑(전체 컬럼 조회용)
+	private HugesoInfoDto mapRow(ResultSet rs) throws SQLException {
+		HugesoInfoDto dto = new HugesoInfoDto();
+
+		dto.setH_num(rs.getString("h_num"));
+		dto.setH_name(rs.getString("h_name"));
+		dto.setH_xvalue(rs.getString("h_xvalue"));
+		dto.setH_yvalue(rs.getString("h_yvalue"));
+		dto.setH_photo(rs.getString("h_photo"));
+		dto.setH_hp(rs.getString("h_hp"));
+		dto.setH_addr(rs.getString("h_addr"));
+		dto.setH_pyeon(rs.getString("h_pyeon"));
+		dto.setH_gasolin(rs.getString("h_gasolin"));
+		dto.setH_disel(rs.getString("h_disel"));
+		dto.setH_lpg(rs.getString("h_lpg"));
+		dto.setH_grade(rs.getString("h_grade"));
+		dto.setH_gradecount(rs.getString("h_gradecount"));
+
+		return dto;
+	}
+
 	//전체데이터 List에 담아서 리턴하는 메서드
-		public List<HugesoInfoDto> getAllDatas(){
-			List<HugesoInfoDto> list = new Vector<HugesoInfoDto>();
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql ="select * from hugesoinfo order by h_num";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				rs=pstmt.executeQuery();
-				
-				while(rs.next()) {
-					HugesoInfoDto dto = new HugesoInfoDto();
-					
-					dto.setH_num(rs.getString("h_num"));
-					dto.setH_name(rs.getString("h_name"));
-					dto.setH_xvalue(rs.getString("h_xvalue"));
-					dto.setH_yvalue(rs.getString("h_yvalue"));
-					dto.setH_photo(rs.getString("h_photo"));
-					dto.setH_hp(rs.getString("h_hp"));
-					dto.setH_addr(rs.getString("h_addr"));
-					dto.setH_pyeon(rs.getString("h_pyeon"));
-					dto.setH_gasolin(rs.getString("h_gasolin"));
-					dto.setH_disel(rs.getString("h_disel"));
-					dto.setH_lpg(rs.getString("h_lpg"));
-					dto.setH_grade(rs.getString("h_grade"));
-					dto.setH_gradecount(rs.getString("h_gradecount"));
-					
-					
-					list.add(dto);
-				}
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-				return list;
-				
-		}
-		
-		//페이징..1.전체갯수반환   2.부분조회(startnum부터 perpage갯수만큼 반환)
-				//1.전체갯수반환  
-				
-				public int getTotalCount()
-				{
-					
-					int total=0;
-					Connection conn=db.getConnection();
-					PreparedStatement pstmt=null;
-					ResultSet rs=null;
-					
-					String sql="select count(*) from hugesoinfo";
-					
-					try {
-						pstmt=conn.prepareStatement(sql);
-						rs=pstmt.executeQuery();
-						
-						if(rs.next())
-							total=rs.getInt(1);
-					} catch (SQLException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-					
-					
-					return total;
-				}
-				
-				//2.부분조회(startnum부터 perpage갯수만큼 반환)
-				public List<HugesoInfoDto> getPagingList(int startNum,int perPage)
-				{
-					List<HugesoInfoDto> list=new ArrayList<HugesoInfoDto>();
-					
-					Connection conn=db.getConnection();
-					PreparedStatement pstmt=null;
-					ResultSet rs=null;
-					
-					String sql="select * from hugesoinfo order by h_num limit ?,?";
-					
-					try {
-						pstmt=conn.prepareStatement(sql);
-						
-						pstmt.setInt(1, startNum);
-						pstmt.setInt(2, perPage);
-						
-						rs=pstmt.executeQuery();
-						
-						while(rs.next())
-						{
-							HugesoInfoDto dto=new HugesoInfoDto();
-							
-							dto.setH_num(rs.getString("h_num"));
-							dto.setH_name(rs.getString("h_name"));
-							dto.setH_xvalue(rs.getString("h_xvalue"));
-							dto.setH_yvalue(rs.getString("h_yvalue"));
-							dto.setH_photo(rs.getString("h_photo"));
-							dto.setH_hp(rs.getString("h_hp"));
-							dto.setH_addr(rs.getString("h_addr"));
-							dto.setH_pyeon(rs.getString("h_pyeon"));
-							dto.setH_gasolin(rs.getString("h_gasolin"));
-							dto.setH_disel(rs.getString("h_disel"));
-							dto.setH_lpg(rs.getString("h_lpg"));
-							dto.setH_grade(rs.getString("h_grade"));
-							dto.setH_gradecount(rs.getString("h_gradecount"));
-							
-							list.add(dto);
-						}
-						
-						
-					} catch (SQLException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-					
-					
-					return list;
-					
-				}
-				
-				
-				//h_num에 해당하는 휴게소 데이터 리턴 (hugesodetail.jsp)
-				public HugesoInfoDto getData(String h_num) {
-					HugesoInfoDto dto = new HugesoInfoDto();
-					
-					Connection conn = db.getConnection();
-					PreparedStatement pstmt=null;
-					ResultSet rs = null;
-					
-					String sql ="select * from hugesoinfo where h_num=?";
-					
-					try {
-						pstmt=conn.prepareStatement(sql);
-						pstmt.setString(1, h_num);
-						rs=pstmt.executeQuery();
-						
-						if(rs.next()) {
-							dto.setH_num(rs.getString("h_num"));
-							dto.setH_name(rs.getString("h_name"));
-							dto.setH_xvalue(rs.getString("h_xvalue"));
-							dto.setH_yvalue(rs.getString("h_yvalue"));
-							dto.setH_photo(rs.getString("h_photo"));
-							dto.setH_hp(rs.getString("h_hp"));
-							dto.setH_addr(rs.getString("h_addr"));
-							dto.setH_pyeon(rs.getString("h_pyeon"));
-							dto.setH_gasolin(rs.getString("h_gasolin"));
-							dto.setH_disel(rs.getString("h_disel"));
-							dto.setH_lpg(rs.getString("h_lpg"));
-							dto.setH_grade(rs.getString("h_grade"));
-							dto.setH_gradecount(rs.getString("h_gradecount"));
-						}
-					} catch (SQLException e) {
-						e.printStackTrace();
-					}finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-					
-					return dto;
-				}
-				
-				
-				//휴게소 즐겨찾기 (hugesodetail.jsp)
-				public void favorite(FavoriteDto dto)
-				{
-					Connection conn=db.getConnection();
-					PreparedStatement pstmt=null;
-					
-					String sql="insert into favorite values(null,?,?)";
-					
-					try {
-						pstmt=conn.prepareStatement(sql);
-						
-						pstmt.setString(1, dto.getM_num());
-						pstmt.setString(2, dto.getH_num());
-						
-						pstmt.execute();
-					} catch (SQLException e) {
-						e.printStackTrace();
-					}finally {
-						db.dbClose(pstmt, conn);
-					}
-					
-				}
-				
-				
-				//휴게소 즐겨찾기 해제 (hugesodetail.jsp)
-				//유지))f_num을 구해도 바로 반영이 되지 않아서 결국 m_num과 h_num이 일치할때 삭제되게끔 수정함
-				public void deleteFavorite(String m_num,String h_num)
-				{
-					Connection conn=db.getConnection();
-					PreparedStatement pstmt=null;
-					
-					String sql="delete from favorite where m_num=? and h_num=?";
-					
-					try {
-						pstmt=conn.prepareStatement(sql);
-						pstmt.setString(1, m_num);
-						pstmt.setString(2, h_num);
-						pstmt.execute();
-						
-					} catch (SQLException e) {
-						e.printStackTrace();
-					}finally {
-						db.dbClose(pstmt, conn);
-					}
-					
-				}
-	
-	public List<HugesoInfoDto> searchHugesoinfo(String h_name){
-		List<HugesoInfoDto> list=new ArrayList<HugesoInfoDto>();
-		
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-		ResultSet rs=null;
-		
-		String sql="select * from hugesoinfo where h_name like ?";
-		
+	public List<HugesoInfoDto> getAllDatas(){
+		List<HugesoInfoDto> list = new Vector<HugesoInfoDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql ="select * from hugesoinfo order by h_num";
+
 		try {
-			pstmt=conn.prepareStatement(sql);
-			
-			pstmt.setString(1, "%"+h_name+"%");
-			
+			pstmt = conn.prepareStatement(sql);
 			rs=pstmt.executeQuery();
-			
+
 			while(rs.next()) {
-				HugesoInfoDto dto=new HugesoInfoDto();
-				
-				dto.setH_num(rs.getString("h_num"));
-				dto.setH_name(rs.getString("h_name"));
-				dto.setH_xvalue(rs.getString("h_xvalue"));
-				dto.setH_yvalue(rs.getString("h_yvalue"));
-				dto.setH_photo(rs.getString("h_photo"));
-				dto.setH_hp(rs.getString("h_hp"));
-				dto.setH_addr(rs.getString("h_addr"));
-				dto.setH_pyeon(rs.getString("h_pyeon"));
-				dto.setH_gasolin(rs.getString("h_gasolin"));
-				dto.setH_disel(rs.getString("h_disel"));
-				dto.setH_lpg(rs.getString("h_lpg"));
-				dto.setH_grade(rs.getString("h_grade"));
-				dto.setH_gradecount(rs.getString("h_gradecount"));
-				
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-		
+		return list;
+	}
+
+	//페이징..1.전체갯수반환   2.부분조회(startnum부터 perpage갯수만큼 반환)
+	//1.전체갯수반환
+	public int getTotalCount() {
+		int total=0;
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+		ResultSet rs=null;
+
+		String sql="select count(*) from hugesoinfo";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			rs=pstmt.executeQuery();
+
+			if(rs.next())
+				total=rs.getInt(1);
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+	}
+
+	//2.부분조회(startnum부터 perpage갯수만큼 반환)
+	public List<HugesoInfoDto> getPagingList(int startNum,int perPage) {
+		List<HugesoInfoDto> list=new ArrayList<HugesoInfoDto>();
+
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+		ResultSet rs=null;
+
+		String sql="select * from hugesoinfo order by h_num limit ?,?";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+
+			pstmt.setInt(1, startNum);
+			pstmt.setInt(2, perPage);
+
+			rs=pstmt.executeQuery();
+
+			while(rs.next()) {
+				list.add(mapRow(rs));
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return list;
+	}
+
+	//h_num에 해당하는 휴게소 데이터 리턴 (hugesodetail.jsp)
+	public HugesoInfoDto getData(String h_num) {
+		HugesoInfoDto dto = new HugesoInfoDto();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt=null;
+		ResultSet rs = null;
+
+		String sql ="select * from hugesoinfo where h_num=?";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			pstmt.setString(1, h_num);
+			rs=pstmt.executeQuery();
+
+			if(rs.next()) {
+				dto = mapRow(rs);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return dto;
+	}
+
+	//휴게소 즐겨찾기 (hugesodetail.jsp)
+	public void insertFavorite(FavoriteDto dto) {
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+
+		String sql="insert into favorite values(null,?,?)";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getM_num());
+			pstmt.setString(2, dto.getH_num());
+
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	//휴게소 즐겨찾기 해제 (hugesodetail.jsp)
+	//유지))f_num을 구해도 바로 반영이 되지 않아서 결국 m_num과 h_num이 일치할때 삭제되게끔 수정함
+	public void deleteFavorite(String m_num,String h_num) {
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+
+		String sql="delete from favorite where m_num=? and h_num=?";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			pstmt.setString(1, m_num);
+			pstmt.setString(2, h_num);
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	public List<HugesoInfoDto> searchHugesoinfo(String h_name){
+		List<HugesoInfoDto> list=new ArrayList<HugesoInfoDto>();
+
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+		ResultSet rs=null;
+
+		String sql="select * from hugesoinfo where h_name like ?";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+
+			pstmt.setString(1, "%"+h_name+"%");
+
+			rs=pstmt.executeQuery();
+
+			while(rs.next()) {
+				list.add(mapRow(rs));
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
 		return list;
 	}
 
 	//유지))휴게소 이름하고 넘버가 필요해서 작성했어요. 나중에 수정되거나 삭제될 가능성 있음. foodcourt/choice에서 사용함
 	public List<HugesoInfoDto> getH_numH_name(){
 		List<HugesoInfoDto> list = new Vector<HugesoInfoDto>();
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-		
+
 		String sql ="select h_num,h_name from hugesoinfo order by h_num";
-		
+
 		try {
 			pstmt = conn.prepareStatement(sql);
 			rs=pstmt.executeQuery();
-			
+
 			while(rs.next()) {
 				HugesoInfoDto dto = new HugesoInfoDto();
-				
+
 				dto.setH_num(rs.getString("h_num"));
 				dto.setH_name(rs.getString("h_name"));
 				list.add(dto);
 			}
-     } catch (SQLException e) {
-			// TODO Auto-generated catch block
+		} catch (SQLException e) {
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-    return list;
-  }
+		return list;
+	}
 
 	// 검색 결과 총 갯수
-	public int getSearchTotalCount(String h_name)
-	{
-		
+	public int getSearchTotalCount(String h_name) {
 		int total=0;
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
 		ResultSet rs=null;
-		
+
 		String sql="select count(*) from hugesoinfo where h_name like ?";
-		
+
 		try {
 			pstmt=conn.prepareStatement(sql);
 			pstmt.setString(1, "%"+h_name+"%");
 			rs=pstmt.executeQuery();
-			
+
 			if(rs.next())
 				total=rs.getInt(1);
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-		
-		
+
 		return total;
 	}
-	
+
 	//검색결과 부분조회
-	public List<HugesoInfoDto> getSearchPagingList(String h_name,int startNum,int perPage)
-	{
+	public List<HugesoInfoDto> getSearchPagingList(String h_name,int startNum,int perPage) {
 		List<HugesoInfoDto> list=new ArrayList<HugesoInfoDto>();
-		
+
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
 		ResultSet rs=null;
-		
+
 		String sql="select * from hugesoinfo where h_name like ? order by h_num limit ?,?";
-		
+
 		try {
 			pstmt=conn.prepareStatement(sql);
-			
+
 			pstmt.setString(1, "%"+h_name+"%");
 			pstmt.setInt(2, startNum);
 			pstmt.setInt(3, perPage);
-			
+
 			rs=pstmt.executeQuery();
-			
-			while(rs.next())
-			{
-				HugesoInfoDto dto=new HugesoInfoDto();
-				
-				dto.setH_num(rs.getString("h_num"));
-				dto.setH_name(rs.getString("h_name"));
-				dto.setH_xvalue(rs.getString("h_xvalue"));
-				dto.setH_yvalue(rs.getString("h_yvalue"));
-				dto.setH_photo(rs.getString("h_photo"));
-				dto.setH_hp(rs.getString("h_hp"));
-				dto.setH_addr(rs.getString("h_addr"));
-				dto.setH_pyeon(rs.getString("h_pyeon"));
-				dto.setH_gasolin(rs.getString("h_gasolin"));
-				dto.setH_disel(rs.getString("h_disel"));
-				dto.setH_lpg(rs.getString("h_lpg"));
-				dto.setH_grade(rs.getString("h_grade"));
-				dto.setH_gradecount(rs.getString("h_gradecount"));
-				
-				list.add(dto);
+
+			while(rs.next()) {
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
-		}		
+		}
 		return list;
-		
 	}
-	
+
 	public void insertHugesoinfo(HugesoInfoDto dto) {
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
-		
+
 		String sql="insert into hugesoinfo(h_name,h_photo,h_hp,h_addr,h_xvalue,h_yvalue,h_pyeon,h_gasolin,h_disel,h_lpg,h_grade,h_gradecount) values(?,?,?,?,?,?,?,?,?,?,0,0)";
-		
+
 		try {
 			pstmt=conn.prepareStatement(sql);
-			
+
 			pstmt.setString(1, dto.getH_name());
 			pstmt.setString(2, dto.getH_photo());
 			pstmt.setString(3, dto.getH_hp());
@@ -406,164 +319,140 @@ public class HugesoInfoDao {
 			pstmt.setString(8, dto.getH_gasolin());
 			pstmt.setString(9, dto.getH_disel());
 			pstmt.setString(10, dto.getH_lpg());
-			
+
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
 		}
 	}
-	
+
 	public String selectHugesoNum(String h_xvalue, String h_yvalue) {
 		String h_num="0";
-		
+
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
 		ResultSet rs=null;
-		
+
 		String sql="select h_num from hugesoinfo where h_xvalue=? and h_yvalue=?";
-		
+
 		try {
 			pstmt=conn.prepareStatement(sql);
-			
+
 			pstmt.setString(1, h_xvalue);
 			pstmt.setString(2, h_yvalue);
-			
+
 			rs=pstmt.executeQuery();
-			
+
 			if(rs.next()) {
 				h_num=rs.getString("h_num");
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-		
+
 		return h_num;
 	}
-	
+
 	//평균 평점(h_grade),평점 갯수(h_gradecount) hugesoinfo에 update
-		public void updateH_grade(HugesoInfoDto dto) {
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-			
-			String sql="update hugesoinfo set h_grade=?, h_gradecount=? where h_num=?";
-			
-			try {
-				pstmt=conn.prepareStatement(sql);
-				
-				pstmt.setString(1, dto.getH_grade());
-				pstmt.setString(2, dto.getH_gradecount());
-				pstmt.setString(3, dto.getH_num());
-				
-				pstmt.execute();
-			    } catch (SQLException e) {
-			        e.printStackTrace();
-			    }finally {
-				db.dbClose(pstmt, conn);
-			}
-			
-		}
+	public void updateH_grade(HugesoInfoDto dto) {
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
 
-		//승경_메인화면에 휴게소 평점 순위대로 가져오기 위해 생성
-        public List<HugesoInfoDto> getAllGrade(){
-           List<HugesoInfoDto> gradelist = new ArrayList<HugesoInfoDto>();
-           
-           Connection conn = db.getConnection();
-           PreparedStatement pstmt = null;
-           ResultSet rs = null;
-           
-           String sql ="select * from hugesoinfo order by h_grade desc";
-           
-           try {
-              pstmt = conn.prepareStatement(sql);
-              rs=pstmt.executeQuery();
-              
-              while(rs.next()) {
-                 HugesoInfoDto dto = new HugesoInfoDto();
-                 
-                 dto.setH_num(rs.getString("h_num"));
-                 dto.setH_name(rs.getString("h_name"));
-                 dto.setH_xvalue(rs.getString("h_xvalue"));
-                 dto.setH_yvalue(rs.getString("h_yvalue"));
-                 dto.setH_photo(rs.getString("h_photo"));
-                 dto.setH_hp(rs.getString("h_hp"));
-                 dto.setH_addr(rs.getString("h_addr"));
-                 dto.setH_pyeon(rs.getString("h_pyeon"));
-                 dto.setH_gasolin(rs.getString("h_gasolin"));
-                 dto.setH_disel(rs.getString("h_disel"));
-                 dto.setH_lpg(rs.getString("h_lpg"));
-                 dto.setH_grade(rs.getString("h_grade"));
-                 dto.setH_gradecount(rs.getString("h_gradecount"));
-                 
-                 
-                 gradelist.add(dto);
-              }
-              
-           } catch (SQLException e) {
-              // TODO Auto-generated catch block
-              e.printStackTrace();
-           }finally {
-              db.dbClose(rs, pstmt, conn);
-           }
-              return gradelist;
-              
-        }
+		String sql="update hugesoinfo set h_grade=?, h_gradecount=? where h_num=?";
 
-		//휴게소정보 업데이트
-		public void updateHugesoinfo(HugesoInfoDto dto) {
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-			
-			String sql="update hugesoinfo set h_name=?,h_xvalue=?,h_yvalue=?,h_photo=?,h_hp=?,h_addr=?,h_pyeon=?,h_gasolin=?,h_disel=?,h_lpg=? where h_num=?";
-			
-			try {
-				pstmt=conn.prepareStatement(sql);
-				
-				pstmt.setString(1, dto.getH_name());
-				pstmt.setString(2, dto.getH_xvalue());
-				pstmt.setString(3, dto.getH_yvalue());
-				pstmt.setString(4, dto.getH_photo());
-				pstmt.setString(5, dto.getH_hp());
-				pstmt.setString(6, dto.getH_addr());
-				pstmt.setString(7, dto.getH_pyeon());
-				pstmt.setString(8, dto.getH_gasolin());
-				pstmt.setString(9, dto.getH_disel());
-				pstmt.setString(10, dto.getH_lpg());
-				pstmt.setString(11, dto.getH_num());
-				
-				pstmt.execute();
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
+		try {
+			pstmt=conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getH_grade());
+			pstmt.setString(2, dto.getH_gradecount());
+			pstmt.setString(3, dto.getH_num());
+
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
 		}
-  
-		//휴게소 삭제
-		public void deleteHugesoinfo(String h_num) {
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-			
-			String sql="delete from hugesoinfo where h_num=?";
-			
-			try {
-				pstmt=conn.prepareStatement(sql);
-				
-				pstmt.setString(1, h_num);
-				
-				pstmt.execute();
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
+	}
+
+	//승경_메인화면에 휴게소 평점 순위대로 가져오기 위해 생성
+	public List<HugesoInfoDto> getAllGrade(){
+		List<HugesoInfoDto> gradelist = new ArrayList<HugesoInfoDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql ="select * from hugesoinfo order by h_grade desc";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs=pstmt.executeQuery();
+
+			while(rs.next()) {
+				gradelist.add(mapRow(rs));
 			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
+		return gradelist;
+	}
+
+	//휴게소정보 업데이트
+	public void updateHugesoinfo(HugesoInfoDto dto) {
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+
+		String sql="update hugesoinfo set h_name=?,h_xvalue=?,h_yvalue=?,h_photo=?,h_hp=?,h_addr=?,h_pyeon=?,h_gasolin=?,h_disel=?,h_lpg=? where h_num=?";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getH_name());
+			pstmt.setString(2, dto.getH_xvalue());
+			pstmt.setString(3, dto.getH_yvalue());
+			pstmt.setString(4, dto.getH_photo());
+			pstmt.setString(5, dto.getH_hp());
+			pstmt.setString(6, dto.getH_addr());
+			pstmt.setString(7, dto.getH_pyeon());
+			pstmt.setString(8, dto.getH_gasolin());
+			pstmt.setString(9, dto.getH_disel());
+			pstmt.setString(10, dto.getH_lpg());
+			pstmt.setString(11, dto.getH_num());
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	//휴게소 삭제
+	public void deleteHugesoinfo(String h_num) {
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+
+		String sql="delete from hugesoinfo where h_num=?";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+
+			pstmt.setString(1, h_num);
+
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
 }

--- a/src/main/webapp/foodcourt/choicehuegeso.jsp
+++ b/src/main/webapp/foodcourt/choicehuegeso.jsp
@@ -89,7 +89,7 @@
 </style>
 <%
 HugesoInfoDao dao=new HugesoInfoDao();
-List<HugesoInfoDto> list=dao.getH_numH_name();
+List<HugesoInfoDto> list=dao.selectH_numH_name();
 %>
 </head>
 <body>

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -232,7 +232,7 @@ MemInfoDao mdao=new MemInfoDao();
 String m_num=mdao.getM_num(m_id);
 //휴게소 이름 가져오기
 HugesoInfoDao hdao=new HugesoInfoDao();
-HugesoInfoDto hdto=hdao.getData(h_num);
+HugesoInfoDto hdto=hdao.selectData(h_num);
 NumberFormat nf=NumberFormat.getInstance();
 %>
 <div class="img-container" style="border: 0px solid green; background-image: url('image/mainbanner/foodbanner01.png'); background-size: cover; background-position: center center;">

--- a/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
@@ -56,7 +56,7 @@
 	HugesoInfoDto hdto=new HugesoInfoDto();
 	
 	//휴게소 파일삭제
-	String filePath=uploadPath+"/"+hdao.getData(h_num).getH_photo();
+	String filePath=uploadPath+"/"+hdao.selectData(h_num).getH_photo();
 	File file=new File(filePath);
 	if(file.exists()){
 		file.delete();

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -44,7 +44,7 @@
 	
     // HugesoInfoDao 객체 생성 & 휴게소 데이터 가져오기
     HugesoInfoDao dao = new HugesoInfoDao();
-	HugesoInfoDto dto = dao.getData(h_num);
+	HugesoInfoDto dto = dao.selectData(h_num);
 	
 	SimpleDateFormat sdf=new SimpleDateFormat("yy.MM.dd");
 

--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -224,10 +224,6 @@ color: black;
 	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
 	no=totalCount-(currentPage-1)*perPage;
 
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
-
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=hdao.getPagingList(startNum, perPage);
 %>

--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -185,7 +185,7 @@ color: black;
 	HugesoInfoDao hdao = new HugesoInfoDao();
 	 
 	//전체갯수
-	int totalCount=hdao.getTotalCount();
+	int totalCount=hdao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -225,7 +225,7 @@ color: black;
 	no=totalCount-(currentPage-1)*perPage;
 
 	//페이지에서 보여질 글만 가져오기
-	List<HugesoInfoDto>list2=hdao.getPagingList(startNum, perPage);
+	List<HugesoInfoDto>list2=hdao.selectPagingList(startNum, perPage);
 %>
 <body>
 

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -176,10 +176,6 @@ a:active{
 	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
 	no=totalCount-(currentPage-1)*perPage;
 
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
-
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=dao.selectPagingList(startNum, perPage);
 	

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -133,8 +133,6 @@ a:active{
 
     //UploadBoardDao 인스턴스 생성
 	HugesoInfoDao dao = new HugesoInfoDao();
-    //모든 게시글 데이터 가져오기
-	List<HugesoInfoDto> list = dao.selectAllDatas();
 	 
 	//전체갯수
 	int totalCount=dao.selectTotalCount();

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -134,10 +134,10 @@ a:active{
     //UploadBoardDao 인스턴스 생성
 	HugesoInfoDao dao = new HugesoInfoDao();
     //모든 게시글 데이터 가져오기
-	List<HugesoInfoDto> list = dao.getAllDatas();
+	List<HugesoInfoDto> list = dao.selectAllDatas();
 	 
 	//전체갯수
-	int totalCount=dao.getTotalCount();
+	int totalCount=dao.selectTotalCount();
 	int perPage=9; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -181,7 +181,7 @@ a:active{
 	no=totalCount-(currentPage-1)*perPage;
 
 	//페이지에서 보여질 글만 가져오기
-	List<HugesoInfoDto>list2=dao.getPagingList(startNum, perPage);
+	List<HugesoInfoDto>list2=dao.selectPagingList(startNum, perPage);
 	
 %>
 

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -98,8 +98,6 @@ a:active{
 	String h_name=request.getParameter("h_name");
     //UploadBoardDao 인스턴스 생성
 	HugesoInfoDao dao = new HugesoInfoDao();
-    //모든 게시글 데이터 가져오기
-	List<HugesoInfoDto> list = dao.selectAllDatas();
 	 
 	//전체갯수
 	int totalCount=dao.selectSearchTotalCount(h_name);

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -99,10 +99,10 @@ a:active{
     //UploadBoardDao 인스턴스 생성
 	HugesoInfoDao dao = new HugesoInfoDao();
     //모든 게시글 데이터 가져오기
-	List<HugesoInfoDto> list = dao.getAllDatas();
+	List<HugesoInfoDto> list = dao.selectAllDatas();
 	 
 	//전체갯수
-	int totalCount=dao.getSearchTotalCount(h_name);
+	int totalCount=dao.selectSearchTotalCount(h_name);
 	int perPage=9; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -146,7 +146,7 @@ a:active{
 	no=totalCount-(currentPage-1)*perPage;
 
 	//페이지에서 보여질 글만 가져오기
-	List<HugesoInfoDto>list2=dao.getSearchPagingList(h_name, startNum, perPage);
+	List<HugesoInfoDto>list2=dao.selectSearchPagingList(h_name, startNum, perPage);
 
 	
 %>

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -141,10 +141,6 @@ a:active{
 	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
 	no=totalCount-(currentPage-1)*perPage;
 
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
-
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=dao.selectSearchPagingList(h_name, startNum, perPage);
 

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -148,7 +148,7 @@ color: black;
 	HugesoInfoDao hdao = new HugesoInfoDao();
 	 
 	//전체갯수
-	int totalCount=hdao.getSearchTotalCount(h_name);
+	int totalCount=hdao.selectSearchTotalCount(h_name);
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -192,7 +192,7 @@ color: black;
 	no=totalCount-(currentPage-1)*perPage;
 
 	//페이지에서 보여질 글만 가져오기
-	List<HugesoInfoDto>list2=hdao.getSearchPagingList(h_name, startNum, perPage);
+	List<HugesoInfoDto>list2=hdao.selectSearchPagingList(h_name, startNum, perPage);
 
 	
 %>

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -187,10 +187,6 @@ color: black;
 	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
 	no=totalCount-(currentPage-1)*perPage;
 
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
-
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=hdao.selectSearchPagingList(h_name, startNum, perPage);
 

--- a/src/main/webapp/hugesoinfo/hugesomap.jsp
+++ b/src/main/webapp/hugesoinfo/hugesomap.jsp
@@ -388,7 +388,7 @@
 	        		<%
 	        			HugesoInfoDao dao=new HugesoInfoDao();
 	        		%>
-	        		var totalCount=<%=dao.getTotalCount() %>; //전체데이터수
+	        		var totalCount=<%=dao.selectTotalCount() %>; //전체데이터수
 	        		var perPage=5; //한페이지당 보여질 글의 갯수
 	        		var perBlock=5; //한블럭당 보여질 페이지 갯수
 	        		var startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);

--- a/src/main/webapp/hugesoinfo/hugesopaging.jsp
+++ b/src/main/webapp/hugesoinfo/hugesopaging.jsp
@@ -16,7 +16,7 @@
 	startNum=(currentPage-1)*perPage;
 	
 	HugesoInfoDao dao=new HugesoInfoDao();
-	List<HugesoInfoDto> list=dao.getPagingList(startNum, perPage);
+	List<HugesoInfoDto> list=dao.selectPagingList(startNum, perPage);
 	
 	JSONArray arr=new JSONArray();
 	

--- a/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
@@ -64,10 +64,10 @@
 		hdto.setH_name(h_name);
 		String h_photo = multi.getFilesystemName("h_photo");
 		if(h_photo==null){
-	    	String oldPhoto=hdao.getData(h_num).getH_photo();
+	    	String oldPhoto=hdao.selectData(h_num).getH_photo();
 	    	hdto.setH_photo(oldPhoto);
 	    }else{
-	    	String filePath=uploadPath+"/"+hdao.getData(h_num).getH_photo();
+	    	String filePath=uploadPath+"/"+hdao.selectData(h_num).getH_photo();
 	    	File file=new File(filePath);
 			if(file.exists()){
 				file.delete();

--- a/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
@@ -23,7 +23,7 @@
 	String h_num=request.getParameter("h_num");
 
 	HugesoInfoDao hdao=new HugesoInfoDao();
-	HugesoInfoDto hdto=hdao.getData(h_num);
+	HugesoInfoDto hdto=hdao.selectData(h_num);
 	
 	String hp = hdto.getH_hp();
 	String[] hpArray = hp.split("-");

--- a/src/main/webapp/hugesoinfo/insertfavorite.jsp
+++ b/src/main/webapp/hugesoinfo/insertfavorite.jsp
@@ -20,5 +20,5 @@
    dto.setH_num(h_num);
    dto.setM_num(m_num);
    
-   dao.favorite(dto);
+   dao.insertFavorite(dto);
 %>

--- a/src/main/webapp/hugesoinfo/mapaction.jsp
+++ b/src/main/webapp/hugesoinfo/mapaction.jsp
@@ -8,7 +8,7 @@
 <%
 	
 	HugesoInfoDao dao=new HugesoInfoDao();
-	List<HugesoInfoDto> list=dao.getAllDatas();
+	List<HugesoInfoDto> list=dao.selectAllDatas();
 	
 	JSONArray arr=new JSONArray();
 	

--- a/src/main/webapp/layout/main.jsp
+++ b/src/main/webapp/layout/main.jsp
@@ -1,5 +1,3 @@
-<%@page import="hugesoinfo.model.HugesoInfoDto"%>
-<%@page import="hugesoinfo.model.HugesoInfoDao"%>
 <%@page import="event.model.EventDto"%>
 <%@page import="event.model.EventDao"%>
 <%@page import="java.text.SimpleDateFormat"%>
@@ -132,10 +130,6 @@ List<NoticeDto> list = ndao.getAllNotice();
 //event
 EventDao edao = new EventDao();
 List<EventDto> elist = edao.getAllEvent();
-
-//휴게소
-HugesoInfoDao hdao = new HugesoInfoDao();
-List<HugesoInfoDto> hlist = hdao.selectAllGrade();
 %>
 <body>
 <div id="total_main">

--- a/src/main/webapp/layout/main.jsp
+++ b/src/main/webapp/layout/main.jsp
@@ -135,7 +135,7 @@ List<EventDto> elist = edao.getAllEvent();
 
 //휴게소
 HugesoInfoDao hdao = new HugesoInfoDao();
-List<HugesoInfoDto> hlist = hdao.getAllGrade();
+List<HugesoInfoDto> hlist = hdao.selectAllGrade();
 %>
 <body>
 <div id="total_main">

--- a/src/main/webapp/mainlayout/hugesorank.jsp
+++ b/src/main/webapp/mainlayout/hugesorank.jsp
@@ -101,7 +101,7 @@
 
    //휴게소
    HugesoInfoDao hdao = new HugesoInfoDao();
-   List<HugesoInfoDto> hlist = hdao.getAllGrade();
+   List<HugesoInfoDto> hlist = hdao.selectAllGrade();
 
 
 %>
@@ -112,7 +112,7 @@
 <div class="swiper-container hugeso">
     <div class="swiper-wrapper">
         <% 
-            List<HugesoInfoDto> recenthugeso = hdao.getAllGrade();
+            List<HugesoInfoDto> recenthugeso = hdao.selectAllGrade();
             int size = Math.min(recenthugeso.size(), 5);
             for (int h = 0; h < size; h++) { 
                 HugesoInfoDto dto = recenthugeso.get(h); 

--- a/src/main/webapp/mainlayout/hugesorank.jsp
+++ b/src/main/webapp/mainlayout/hugesorank.jsp
@@ -101,7 +101,6 @@
 
    //휴게소
    HugesoInfoDao hdao = new HugesoInfoDao();
-   List<HugesoInfoDto> hlist = hdao.selectAllGrade();
 
 
 %>

--- a/src/main/webapp/reviewboard/reviewForm.jsp
+++ b/src/main/webapp/reviewboard/reviewForm.jsp
@@ -28,7 +28,7 @@
 </head>
 <%
   HugesoInfoDao hdao = new HugesoInfoDao();
-  List<HugesoInfoDto> hlist = hdao.getAllDatas();
+  List<HugesoInfoDto> hlist = hdao.selectAllDatas();
   
 %>
 <body>

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -246,7 +246,7 @@
       MemInfoDao rdao = new MemInfoDao();
       //휴게소
       HugesoInfoDao hdao = new HugesoInfoDao();
-      List<HugesoInfoDto> hlist = hdao.getAllDatas();
+      List<HugesoInfoDto> hlist = hdao.selectAllDatas();
       
       for(ReviewDto dto:list) {
     	  

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -1,5 +1,3 @@
-<%@page import="hugesoinfo.model.HugesoInfoDto"%>
-<%@page import="hugesoinfo.model.HugesoInfoDao"%>
 <%@page import="meminfo.model.MemInfoDao"%>
 <%@page import="java.text.SimpleDateFormat"%>
 <%@page import="review.model.ReviewDto"%>
@@ -244,10 +242,7 @@
     
     <%
       MemInfoDao rdao = new MemInfoDao();
-      //휴게소
-      HugesoInfoDao hdao = new HugesoInfoDao();
-      List<HugesoInfoDto> hlist = hdao.selectAllDatas();
-      
+
       for(ReviewDto dto:list) {
     	  
     	   //아이디 얻기

--- a/src/main/webapp/reviewboard/reviewUpdateForm.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateForm.jsp
@@ -62,7 +62,7 @@
    
   
    HugesoInfoDao hdao = new HugesoInfoDao();
-   List<HugesoInfoDto> hlist = hdao.getAllDatas();
+   List<HugesoInfoDto> hlist = hdao.selectAllDatas();
    
  %>
 <body>

--- a/src/main/webapp/shop/shopForm.jsp
+++ b/src/main/webapp/shop/shopForm.jsp
@@ -26,7 +26,7 @@
 </head>
 <%
   HugesoInfoDao hdao = new HugesoInfoDao();
-  List<HugesoInfoDto> hlist = hdao.getAllDatas();
+  List<HugesoInfoDto> hlist = hdao.selectAllDatas();
   
 %>
 <body>


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상)의 첫 도메인으로 **휴게소(hugesoinfo)**를 정리했다.
모두 **동작 보존(순수 리팩터)**이며, 각 단계마다 `src/main/java` 전체 javac 컴파일(EXIT=0)로 검증했다.
1단계 보안 처리(escapeHtml/checkCsrf/isPost/소유자검증)는 전부 그대로 보존했다.

## 변경 내용 (커밋 6개)
1. **DAO 정리** — `HugesoInfoDao`의 13컬럼 ResultSet→DTO 매핑 6곳을 `private mapRow(rs)`로 추출, `favorite()`→`insertFavorite()` 접두어 통일, `db` 필드 private화, `// TODO Auto-generated catch block` 주석 제거, 들여쓰기 K&R+탭 정규화
2. **조회 메서드 `get*`→`select*` 통일** — 8개 메서드 + 타 도메인 포함 호출처 20파일 갱신
3. **목록 JSP 중복 계산 줄 제거** — list/list2/listsearch/list2search의 중복 `no=...` 재대입 제거
4. **앨범뷰 미사용 전체조회 제거**(/simplify) — `hugesolist2`·`hugesolist2search`의 죽은 `selectAllDatas()`
5. **평점/목록 미사용 전체조회 제거**(/code-review) — `hugesorank`·`main`·`reviewList`의 죽은 `hlist` + 고아 import

## 안전장치 / 주의해서 처리한 부분
- `getTotalCount`는 게시판 DAO(Notice/Event/Qa/Review)에도 **동명** 존재 → 휴게소 인스턴스 호출만 정확히 변경, 게시판은 미접촉
- `getData`는 게시판 `getDataXxx`와 substring 충돌 없이 `getData(` 단위로만 치환
- `hugesomap.jsp`의 동명 **JS 함수** `getPagingList`는 DAO와 무관하여 유지
- 죽은 변수 제거는 grep 전수 확인 + `index.jsp`가 동적 `<jsp:include>`라 스코프 누수 없음 확인

## 검증
- `src/main/java` 전체 javac 컴파일 EXIT=0 (Tomcat 런타임 검증은 환경상 불가 — JSP 변경은 grep으로 수신자 타입까지 전수 확인)
- 권장 스모크 테스트: 휴게소목록 → 앨범 토글 → 검색 → 상세 → 즐겨찾기 추가

## 보류(별도 진행)
- **list 4종 구조 통합**: {목록형, 앨범형} × {전체, 검색} 2×2 매트릭스로 교차 링크가 얽혀 있어, 수십 개 href + searchaction 재작성이 필요하나 Tomcat 런타임 검증이 불가하여 무검증 통합은 동작 보존 위배. Tomcat 가용 시점으로 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)