### PR TITLE
회원/인증 도메인 2단계 리팩터(MemInfoDao 위생·mapRow·get→select)

### DIFF
--- a/src/main/java/meminfo/model/MemInfoDao.java
+++ b/src/main/java/meminfo/model/MemInfoDao.java
@@ -8,41 +8,38 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import favorite.model.FavoriteDto;
 import mysql.db.DbConnect;
 import util.SecurityUtil;
 
 public class MemInfoDao {
 
-	DbConnect db=new DbConnect();
-	
-	//즐겨찾기 시 세션에 로그인 된 아이디를 이용해 MemInfo의 m_num을 얻는 메서드 (hugesodetail.jsp)
-			public String getM_num(String m_id)
-			{
-				String m_num="";
-				
-				Connection conn=db.getConnection();
-				PreparedStatement pstmt=null;
-				ResultSet rs=null;
-				
-				String sql="select m_num from meminfo where m_id=?";
-				
-				try {
-					pstmt=conn.prepareStatement(sql);
-					pstmt.setString(1, m_id);
-					rs=pstmt.executeQuery();
-					
-					if(rs.next())
-						m_num=rs.getString("m_num");
-				} catch (SQLException e) {
-					e.printStackTrace();
-				}finally {
-					db.dbClose(rs, pstmt, conn);
-				}
-				
-				
-				return m_num;
-			}
+	private DbConnect db = new DbConnect();
+
+	// 즐겨찾기 시 세션에 로그인 된 아이디를 이용해 MemInfo의 m_num을 얻는 메서드 (hugesodetail.jsp)
+	public String getM_num(String m_id) {
+		String m_num = "";
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select m_num from meminfo where m_id=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, m_id);
+			rs = pstmt.executeQuery();
+
+			if (rs.next())
+				m_num = rs.getString("m_num");
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return m_num;
+	}
 
 	// 회원가입
 	// 주의: dto.getM_pass()는 호출 측(gaipaction.jsp)에서 이미 BCrypt 해시로 변환된 값이어야 한다.
@@ -67,7 +64,6 @@ public class MemInfoDao {
 			pstmt.execute();
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -91,7 +87,6 @@ public class MemInfoDao {
 				isid = rs.getInt(1);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -117,7 +112,6 @@ public class MemInfoDao {
 				isnick = rs.getInt(1);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -145,7 +139,6 @@ public class MemInfoDao {
 			}
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -174,7 +167,6 @@ public class MemInfoDao {
 			}
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -204,7 +196,6 @@ public class MemInfoDao {
 			}
 
 		} catch (SQLException e1) {
-			// TODO Auto-generated catch block
 			e1.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -287,13 +278,11 @@ public class MemInfoDao {
 				dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
 		return dto;
-
 	}
 
 	// 로그인 등에서 사용할 회원 권한(USER/ADMIN) 조회
@@ -341,7 +330,6 @@ public class MemInfoDao {
 				count = rs.getInt(1);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -367,7 +355,6 @@ public class MemInfoDao {
 				m_nick = rs.getString("m_nick");
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -394,251 +381,233 @@ public class MemInfoDao {
 			pstmt.setString(8, dto.getM_num());
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
 		}
-	}	
-		
-		//닉네임을 넣고 현재 닉네임 받아오기
-		public String inputIDGetNick(String m_id)
-		{
-			String m_nick="";
-					
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-			ResultSet rs=null;
-					
-			String sql="select * from meminfo where m_num=?";
-					
-			try {
-				pstmt=conn.prepareStatement(sql);
-				pstmt.setString(1, m_id);
-				rs=pstmt.executeQuery();
-				if(rs.next()) {
-					m_nick=rs.getString("m_nick");
-				}
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-			return m_nick;
-		}
-	
+	}
 
-		//삭제 delete메서드
-		public void deleteMember(String m_num)
-		{
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-			
-			String sql="delete from meminfo where m_num=?";
-			
-			try {
-				pstmt=conn.prepareStatement(sql);
-				pstmt.setString(1, m_num);
-				pstmt.execute();
-        
-      } catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
-		}
+	// 닉네임을 넣고 현재 닉네임 받아오기
+	public String inputIDGetNick(String m_id) {
+		String m_nick = "";
 
-	//유지)즐겨찾기 목록 출력
-	public List<HashMap<String, String>> getFavlist(String m_id){
-		List<HashMap<String, String>> list=new ArrayList<HashMap<String,String>>();
-		
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-		ResultSet rs=null;
-		
-		String sql="select f.f_num,h.h_name,h.h_addr,h.h_pyeon, h.h_num,h.h_hp from hugesoinfo h,favorite f,meminfo m where h.h_num=f.h_num and m.m_num=f.m_num and m.m_id=?";
-		
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from meminfo where m_num=?";
+
 		try {
-			pstmt=conn.prepareStatement(sql);
+			pstmt = conn.prepareStatement(sql);
 			pstmt.setString(1, m_id);
-			rs=pstmt.executeQuery();
-			
-			while(rs.next()) {
-				HashMap<String, String> map=new HashMap<String, String>();
+			rs = pstmt.executeQuery();
+			if (rs.next()) {
+				m_nick = rs.getString("m_nick");
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+		return m_nick;
+	}
+
+	// 삭제 delete메서드
+	public void deleteMember(String m_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "delete from meminfo where m_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, m_num);
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	// 유지)즐겨찾기 목록 출력
+	public List<HashMap<String, String>> getFavlist(String m_id) {
+		List<HashMap<String, String>> list = new ArrayList<HashMap<String, String>>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select f.f_num,h.h_name,h.h_addr,h.h_pyeon, h.h_num,h.h_hp from hugesoinfo h,favorite f,meminfo m where h.h_num=f.h_num and m.m_num=f.m_num and m.m_id=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, m_id);
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+				HashMap<String, String> map = new HashMap<String, String>();
 				map.put("h_num", rs.getString("h_num"));
 				map.put("f_num", rs.getString("f_num"));
 				map.put("h_name", rs.getString("h_name"));
 				map.put("h_addr", rs.getString("h_addr"));
 				map.put("h_pyeon", rs.getString("h_pyeon"));
 				map.put("h_hp", rs.getString("h_hp"));
-				
+
 				list.add(map);
 			}
-			
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
 		return list;
-		
 	}
-	
-	
-	//유지))즐겨찾기한 휴게소인지 여부 판단하는 거
+
+	// 유지))즐겨찾기한 휴게소인지 여부 판단하는 거
 	public int isFavorite(String m_num, String h_num) {
-		int fav=0;
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-		ResultSet rs=null;
-		
-		String sql="select count(*) from favorite where m_num=? and h_num=?";
-		
+		int fav = 0;
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from favorite where m_num=? and h_num=?";
+
 		try {
 			pstmt = conn.prepareStatement(sql);
 			pstmt.setString(1, m_num);
 			pstmt.setString(2, h_num);
-			rs=pstmt.executeQuery();
-			if(rs.next()) {
-				fav=rs.getInt(1);
+			rs = pstmt.executeQuery();
+			if (rs.next()) {
+				fav = rs.getInt(1);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-		
+
 		return fav;
 	}
 
-	
 	// 닉네임, 아이디불러오기 (리뷰에 연동)
-		public String getId(String m_id) {
-			String m_nick = "";
+	public String getId(String m_id) {
+		String m_nick = "";
 
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
 
-			String sql = "select * from meminfo where m_id=?";
+		String sql = "select * from meminfo where m_id=?";
 
-			try {
-				pstmt = conn.prepareStatement(sql);
-				pstmt.setString(1, m_id);
-				rs = pstmt.executeQuery();
-				if (rs.next()) {
-					m_nick = rs.getString("m_nick");
-				}
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(rs, pstmt, conn);
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, m_id);
+			rs = pstmt.executeQuery();
+			if (rs.next()) {
+				m_nick = rs.getString("m_nick");
 			}
-			return m_nick;
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
-		
-		//유지)관리자가 회원관리하기 위한 회원전체목록 출력
-		public List<MemInfoDto> getMemDatas(){
-			List<MemInfoDto> list=new ArrayList<MemInfoDto>();
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-			ResultSet rs=null;
-			
-			String sql="select * from meminfo order by m_num";
-			
-			try {
-				pstmt=conn.prepareStatement(sql);
-				rs=pstmt.executeQuery();
-				
-				while(rs.next()) {
-					MemInfoDto dto=new MemInfoDto();
-					dto.setM_num(rs.getString("m_num"));
-					dto.setM_name(rs.getString("m_name"));
-					dto.setM_nick(rs.getString("m_nick"));
-					dto.setM_id(rs.getString("m_id"));
-					dto.setM_pass(rs.getString("m_pass"));
-					dto.setM_hp1(rs.getString("m_hp1"));
-					dto.setM_hp2(rs.getString("m_hp2"));
-					dto.setM_birth(rs.getString("m_birth"));
-					dto.setM_email(rs.getString("m_email"));
-					dto.setM_role(rs.getString("m_role"));
-					dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
-					list.add(dto);
-				}
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
+		return m_nick;
+	}
 
-			return list;
+	// 유지)관리자가 회원관리하기 위한 회원전체목록 출력
+	public List<MemInfoDto> getMemDatas() {
+		List<MemInfoDto> list = new ArrayList<MemInfoDto>();
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from meminfo order by m_num";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+				MemInfoDto dto = new MemInfoDto();
+				dto.setM_num(rs.getString("m_num"));
+				dto.setM_name(rs.getString("m_name"));
+				dto.setM_nick(rs.getString("m_nick"));
+				dto.setM_id(rs.getString("m_id"));
+				dto.setM_pass(rs.getString("m_pass"));
+				dto.setM_hp1(rs.getString("m_hp1"));
+				dto.setM_hp2(rs.getString("m_hp2"));
+				dto.setM_birth(rs.getString("m_birth"));
+				dto.setM_email(rs.getString("m_email"));
+				dto.setM_role(rs.getString("m_role"));
+				dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
+				list.add(dto);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
 
-		//유지)관리자가 회원목록/관리 페이지에서 회원 이름으로 검색하는 것
-		public List<MemInfoDto> searchMem(String m_name){
-			List<MemInfoDto> list=new ArrayList<MemInfoDto>();
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
-			ResultSet rs=null;
-			
-			String sql="select * from meminfo where m_name like ?";
-			
-			try {
-				pstmt=conn.prepareStatement(sql);
-				pstmt.setString(1,"%"+m_name+"%" );
-				rs=pstmt.executeQuery();
-				
-				while(rs.next()) {
-					MemInfoDto dto=new MemInfoDto();
-					dto.setM_num(rs.getString("m_num"));
-					dto.setM_name(rs.getString("m_name"));
-					dto.setM_id(rs.getString("m_id"));
-					dto.setM_nick(rs.getString("m_nick"));
-					dto.setM_hp1(rs.getString("m_hp1"));
-					dto.setM_hp2(rs.getString("m_hp2"));
-					dto.setM_birth(rs.getString("m_birth"));
-					dto.setM_email(rs.getString("m_email"));
-					dto.setM_role(rs.getString("m_role"));
-					dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
-					list.add(dto);
-				}
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
+		return list;
+	}
 
-			return list;
+	// 유지)관리자가 회원목록/관리 페이지에서 회원 이름으로 검색하는 것
+	public List<MemInfoDto> searchMem(String m_name) {
+		List<MemInfoDto> list = new ArrayList<MemInfoDto>();
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from meminfo where m_name like ?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, "%" + m_name + "%");
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+				MemInfoDto dto = new MemInfoDto();
+				dto.setM_num(rs.getString("m_num"));
+				dto.setM_name(rs.getString("m_name"));
+				dto.setM_id(rs.getString("m_id"));
+				dto.setM_nick(rs.getString("m_nick"));
+				dto.setM_hp1(rs.getString("m_hp1"));
+				dto.setM_hp2(rs.getString("m_hp2"));
+				dto.setM_birth(rs.getString("m_birth"));
+				dto.setM_email(rs.getString("m_email"));
+				dto.setM_role(rs.getString("m_role"));
+				dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
+				list.add(dto);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
 
-		// 소유자 범위 즐겨찾기 삭제 (IDOR 방어: 세션 m_num 소유분만 삭제)
-		// 주의) 소유자 조건 없는 PK-only favDelete(String) 오버로드는 IDOR 위험으로 제거함.
-		//       즐겨찾기 삭제는 반드시 아래 2-인자(f_num, m_num) 메서드만 사용한다.
-		public void favDelete(String f_num, String m_num) {
-			Connection conn=db.getConnection();
-			PreparedStatement pstmt=null;
+		return list;
+	}
 
-			String sql="delete from favorite where f_num=? and m_num=?";
+	// 소유자 범위 즐겨찾기 삭제 (IDOR 방어: 세션 m_num 소유분만 삭제)
+	// 주의) 소유자 조건 없는 PK-only favDelete(String) 오버로드는 IDOR 위험으로 제거함.
+	//       즐겨찾기 삭제는 반드시 아래 2-인자(f_num, m_num) 메서드만 사용한다.
+	public void favDelete(String f_num, String m_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
 
-			try {
-				pstmt=conn.prepareStatement(sql);
-				pstmt.setString(1, f_num);
-				pstmt.setString(2, m_num);
-				pstmt.execute();
-			} catch (SQLException e) {
-				e.printStackTrace();
-			}finally {
-				db.dbClose(pstmt, conn);
-			}
+		String sql = "delete from favorite where f_num=? and m_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, f_num);
+			pstmt.setString(2, m_num);
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
 		}
+	}
 }
-
-	
-

--- a/src/main/java/meminfo/model/MemInfoDao.java
+++ b/src/main/java/meminfo/model/MemInfoDao.java
@@ -33,7 +33,7 @@ public class MemInfoDao {
 	}
 
 	// 즐겨찾기 시 세션에 로그인 된 아이디를 이용해 MemInfo의 m_num을 얻는 메서드 (hugesodetail.jsp)
-	public String getM_num(String m_id) {
+	public String selectM_num(String m_id) {
 		String m_num = "";
 
 		Connection conn = db.getConnection();
@@ -266,8 +266,8 @@ public class MemInfoDao {
 		}
 	}
 
-	// 아이디를 넣고 getAlldatas 저장된 값 받아오기
-	public MemInfoDto getAlldatas(String m_id) {
+	// 아이디를 넣고 회원 전체 정보 받아오기
+	public MemInfoDto selectMemberById(String m_id) {
 		MemInfoDto dto = new MemInfoDto();
 
 		Connection conn = db.getConnection();
@@ -293,7 +293,7 @@ public class MemInfoDao {
 	}
 
 	// 로그인 등에서 사용할 회원 권한(USER/ADMIN) 조회
-	public String getRole(String m_id) {
+	public String selectRole(String m_id) {
 		String role = "USER";
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
@@ -345,7 +345,7 @@ public class MemInfoDao {
 	}
 
 	// num을 넣고 현재 닉네임 받아오기
-	public String getNick(String m_num) {
+	public String selectNickByNum(String m_num) {
 		String m_nick = "";
 
 		Connection conn = db.getConnection();
@@ -473,8 +473,8 @@ public class MemInfoDao {
 		return fav;
 	}
 
-	// 닉네임, 아이디불러오기 (리뷰에 연동)
-	public String getId(String m_id) {
+	// 아이디로 닉네임 조회 (리뷰 등에 연동)
+	public String selectNickById(String m_id) {
 		String m_nick = "";
 
 		Connection conn = db.getConnection();
@@ -499,7 +499,7 @@ public class MemInfoDao {
 	}
 
 	// 유지)관리자가 회원관리하기 위한 회원전체목록 출력
-	public List<MemInfoDto> getMemDatas() {
+	public List<MemInfoDto> selectMemDatas() {
 		List<MemInfoDto> list = new ArrayList<MemInfoDto>();
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;

--- a/src/main/java/meminfo/model/MemInfoDao.java
+++ b/src/main/java/meminfo/model/MemInfoDao.java
@@ -15,6 +15,23 @@ public class MemInfoDao {
 
 	private DbConnect db = new DbConnect();
 
+	// ResultSet 한 행을 MemInfoDto로 매핑 (회원 전체 컬럼)
+	private MemInfoDto mapRow(ResultSet rs) throws SQLException {
+		MemInfoDto dto = new MemInfoDto();
+		dto.setM_num(rs.getString("m_num"));
+		dto.setM_name(rs.getString("m_name"));
+		dto.setM_nick(rs.getString("m_nick"));
+		dto.setM_id(rs.getString("m_id"));
+		dto.setM_pass(rs.getString("m_pass"));
+		dto.setM_hp1(rs.getString("m_hp1"));
+		dto.setM_hp2(rs.getString("m_hp2"));
+		dto.setM_birth(rs.getString("m_birth"));
+		dto.setM_email(rs.getString("m_email"));
+		dto.setM_role(rs.getString("m_role"));
+		dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
+		return dto;
+	}
+
 	// 즐겨찾기 시 세션에 로그인 된 아이디를 이용해 MemInfo의 m_num을 얻는 메서드 (hugesodetail.jsp)
 	public String getM_num(String m_id) {
 		String m_num = "";
@@ -265,17 +282,7 @@ public class MemInfoDao {
 			rs = pstmt.executeQuery();
 
 			if (rs.next()) {
-				dto.setM_num(rs.getString("m_num"));
-				dto.setM_name(rs.getString("m_name"));
-				dto.setM_nick(rs.getString("m_nick"));
-				dto.setM_id(rs.getString("m_id"));
-				dto.setM_pass(rs.getString("m_pass"));
-				dto.setM_hp1(rs.getString("m_hp1"));
-				dto.setM_hp2(rs.getString("m_hp2"));
-				dto.setM_birth(rs.getString("m_birth"));
-				dto.setM_email(rs.getString("m_email"));
-				dto.setM_role(rs.getString("m_role"));
-				dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
+				dto = mapRow(rs);
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -505,19 +512,7 @@ public class MemInfoDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-				MemInfoDto dto = new MemInfoDto();
-				dto.setM_num(rs.getString("m_num"));
-				dto.setM_name(rs.getString("m_name"));
-				dto.setM_nick(rs.getString("m_nick"));
-				dto.setM_id(rs.getString("m_id"));
-				dto.setM_pass(rs.getString("m_pass"));
-				dto.setM_hp1(rs.getString("m_hp1"));
-				dto.setM_hp2(rs.getString("m_hp2"));
-				dto.setM_birth(rs.getString("m_birth"));
-				dto.setM_email(rs.getString("m_email"));
-				dto.setM_role(rs.getString("m_role"));
-				dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -543,18 +538,7 @@ public class MemInfoDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-				MemInfoDto dto = new MemInfoDto();
-				dto.setM_num(rs.getString("m_num"));
-				dto.setM_name(rs.getString("m_name"));
-				dto.setM_id(rs.getString("m_id"));
-				dto.setM_nick(rs.getString("m_nick"));
-				dto.setM_hp1(rs.getString("m_hp1"));
-				dto.setM_hp2(rs.getString("m_hp2"));
-				dto.setM_birth(rs.getString("m_birth"));
-				dto.setM_email(rs.getString("m_email"));
-				dto.setM_role(rs.getString("m_role"));
-				dto.setM_gaipday(rs.getTimestamp("M_gaipday"));
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();

--- a/src/main/java/meminfo/model/MemInfoDao.java
+++ b/src/main/java/meminfo/model/MemInfoDao.java
@@ -387,31 +387,6 @@ public class MemInfoDao {
 		}
 	}
 
-	// 닉네임을 넣고 현재 닉네임 받아오기
-	public String inputIDGetNick(String m_id) {
-		String m_nick = "";
-
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-
-		String sql = "select * from meminfo where m_num=?";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, m_id);
-			rs = pstmt.executeQuery();
-			if (rs.next()) {
-				m_nick = rs.getString("m_nick");
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-		return m_nick;
-	}
-
 	// 삭제 delete메서드
 	public void deleteMember(String m_num) {
 		Connection conn = db.getConnection();

--- a/src/main/webapp/eventboard/eventDetail.jsp
+++ b/src/main/webapp/eventboard/eventDetail.jsp
@@ -135,7 +135,7 @@
       
     	  
     	   //아이디 얻기
-    	    String name = rdao.getId(dto.getE_myid());
+    	    String name = rdao.selectNickById(dto.getE_myid());
 
     	  %>
       

--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -223,7 +223,7 @@
         	  for(EventDto dto:list) {
         	  
         	   //아이디 얻기
-        	   String name = edao.getId(dto.getE_myid());
+        	   String name = edao.selectNickById(dto.getE_myid());
         		%>
         		
         		  <tr>

--- a/src/main/webapp/foodcourt/cartalldelete.jsp
+++ b/src/main/webapp/foodcourt/cartalldelete.jsp
@@ -8,7 +8,7 @@ if(!util.SecurityUtil.isLogin(session)){
 }
 // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
 if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
-String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
+String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 FoodCartDao dao=new FoodCartDao();
 dao.deleteAllCart(m_num);
 %>

--- a/src/main/webapp/foodcourt/foodcartaddaction.jsp
+++ b/src/main/webapp/foodcourt/foodcartaddaction.jsp
@@ -21,7 +21,7 @@ if(!util.SecurityUtil.isLogin(session)){
 if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 String f_num=request.getParameter("f_num");
 String h_num=request.getParameter("h_num");
-String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
+String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 int cart_cnt=Integer.parseInt(request.getParameter("cart_cnt"));
 
 FoodCartDao dao=new FoodCartDao();

--- a/src/main/webapp/foodcourt/foodcartdelete.jsp
+++ b/src/main/webapp/foodcourt/foodcartdelete.jsp
@@ -10,7 +10,7 @@ if(!util.SecurityUtil.isLogin(session)){
 if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 String cart_idx=request.getParameter("cart_idx");
 // 소유자는 클라이언트 입력을 신뢰하지 않고 세션 사용자로부터 서버에서 도출(IDOR 방지)
-String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
+String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 FoodCartDao dao=new FoodCartDao();
 dao.deleteCart(cart_idx, m_num);
 %>

--- a/src/main/webapp/foodcourt/foodcartlist.jsp
+++ b/src/main/webapp/foodcourt/foodcartlist.jsp
@@ -11,7 +11,7 @@ if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
 // 소유자(m_num)는 클라이언트 입력을 신뢰하지 않고 세션 사용자로부터 서버에서 도출(읽기 IDOR 방지)
-String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
+String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 String h_num=request.getParameter("h_num");
 
 FoodCartDao dao=new FoodCartDao();

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -229,7 +229,7 @@ FoodDao dao=new FoodDao();
 List<FoodDto> list=dao.getMenu(h_num);
 //로그인했을때 해당아이디로 주문한 메뉴 보이게
 MemInfoDao mdao=new MemInfoDao();
-String m_num=mdao.getM_num(m_id);
+String m_num=mdao.selectM_num(m_id);
 //휴게소 이름 가져오기
 HugesoInfoDao hdao=new HugesoInfoDao();
 HugesoInfoDto hdto=hdao.selectData(h_num);
@@ -274,7 +274,7 @@ NumberFormat nf=NumberFormat.getInstance();
 <%
 FoodCartDao cdao=new FoodCartDao();
 List<HashMap<String,String>> clist=cdao.getCartMenu(m_num, h_num);
-MemInfoDto dto=mdao.getAlldatas(m_id);
+MemInfoDto dto=mdao.selectMemberById(m_id);
 
 %>
 </div>

--- a/src/main/webapp/hugesoinfo/checkfavorite.jsp
+++ b/src/main/webapp/hugesoinfo/checkfavorite.jsp
@@ -10,7 +10,7 @@ if(!util.SecurityUtil.isLogin(session)){
 	response.sendError(403); return;
 }
 MemInfoDao dao=new MemInfoDao();
-String m_num=dao.getM_num(util.SecurityUtil.currentId(session));
+String m_num=dao.selectM_num(util.SecurityUtil.currentId(session));
 String h_num=request.getParameter("h_num");
 
 int fav=dao.isFavorite(m_num, h_num);

--- a/src/main/webapp/hugesoinfo/deletefavorite.jsp
+++ b/src/main/webapp/hugesoinfo/deletefavorite.jsp
@@ -9,7 +9,7 @@
 		// 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
 		if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
 		//유지))삭제메서드 수정
-    String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
+    String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 		String h_num=request.getParameter("h_num");
     HugesoInfoDao dao=new HugesoInfoDao();
     dao.deleteFavorite(m_num, h_num);

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -40,7 +40,7 @@
 	// MemInfoDao 인스턴스 생성
 	MemInfoDao mdao = new MemInfoDao();
 	// 현재 로그인된 member의 아이디를 통해 해당 member의 m_num 조회
-	String m_num = mdao.getM_num(m_id);
+	String m_num = mdao.selectM_num(m_id);
 	
     // HugesoInfoDao 객체 생성 & 휴게소 데이터 가져오기
     HugesoInfoDao dao = new HugesoInfoDao();

--- a/src/main/webapp/hugesoinfo/insertfavorite.jsp
+++ b/src/main/webapp/hugesoinfo/insertfavorite.jsp
@@ -12,7 +12,7 @@
    // 상태변경은 POST + CSRF 토큰 검증(위조 요청 차단)
    if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){ response.sendError(403); return; }
    String h_num=request.getParameter("h_num");
-   String m_num=new meminfo.model.MemInfoDao().getM_num(util.SecurityUtil.currentId(session));
+   String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 
    HugesoInfoDao dao=new HugesoInfoDao();
    FavoriteDto dto=new FavoriteDto();

--- a/src/main/webapp/member/loginaction.jsp
+++ b/src/main/webapp/member/loginaction.jsp
@@ -35,7 +35,7 @@ if(b){
 	session.setAttribute("loginok", "yes");
 	session.setAttribute("myid", id);
 	// 권한(USER/ADMIN)을 세션에 저장 — 관리자 판별은 이 값으로만 한다
-	session.setAttribute("role", dao.getRole(id));
+	session.setAttribute("role", dao.selectRole(id));
 	session.setAttribute("saveok", cbsave==null?null:"yes" );
 	response.sendRedirect("../index.jsp");
 	

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -341,7 +341,7 @@ font-size: 14px;
 			</tr>
 		<%
 	      MemInfoDao mdao=new MemInfoDao();
-		  String name=mdao.getId(myid);
+		  String name=mdao.selectNickById(myid);
 		 
 	        
           //게시물이 없는 경우

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -338,7 +338,7 @@ font-size: 14px;
 			</tr>
 		<%
 	      MemInfoDao mdao=new MemInfoDao();
-		  String name=mdao.getId(myid);
+		  String name=mdao.selectNickById(myid);
 		 
 	        
           //게시물이 없는 경우

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -338,7 +338,7 @@ font-size: 14px;
 			</tr>
 		<%
 	      MemInfoDao mdao=new MemInfoDao();
-		  String name=mdao.getId(myid);
+		  String name=mdao.selectNickById(myid);
 		 
 	        
           //게시물이 없는 경우

--- a/src/main/webapp/mypage/deleteaction.jsp
+++ b/src/main/webapp/mypage/deleteaction.jsp
@@ -44,7 +44,7 @@
 	}
 
 	// 폼의 m_num을 신뢰하지 않고 로그인 사용자 본인 계정만 삭제
-	String m_num=dao.getAlldatas(myid).getM_num();
+	String m_num=dao.selectMemberById(myid).getM_num();
 	dao.deleteMember(m_num);
 
 	// 세션 무효화 (로그아웃)

--- a/src/main/webapp/mypage/deleteform.jsp
+++ b/src/main/webapp/mypage/deleteform.jsp
@@ -61,7 +61,7 @@
 	String myid=(String)session.getAttribute("myid");
 	
 	MemInfoDao dao = new MemInfoDao();
-	MemInfoDto dto = dao.getAlldatas(myid);
+	MemInfoDto dto = dao.selectMemberById(myid);
 	
 	
 %>

--- a/src/main/webapp/mypage/favdelete.jsp
+++ b/src/main/webapp/mypage/favdelete.jsp
@@ -11,6 +11,6 @@ if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
 String f_num=util.SecurityUtil.digitsOnly(request.getParameter("f_num"));
 MemInfoDao dao=new MemInfoDao();
 // IDOR 방어: m_num을 세션 사용자로부터 도출해 본인 소유분만 삭제
-String m_num=dao.getM_num(util.SecurityUtil.currentId(session));
+String m_num=dao.selectM_num(util.SecurityUtil.currentId(session));
 dao.favDelete(f_num, m_num);
 %>

--- a/src/main/webapp/mypage/memberlist.jsp
+++ b/src/main/webapp/mypage/memberlist.jsp
@@ -145,7 +145,7 @@ function delemem(m_num){
 <body>
 <%
 MemInfoDao dao=new MemInfoDao();
-List<MemInfoDto> list=dao.getMemDatas();
+List<MemInfoDto> list=dao.selectMemDatas();
 SimpleDateFormat sdf=new SimpleDateFormat("yyyy-MM-dd");
 %>
 

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -332,7 +332,7 @@ font-size: 14px;
          </tr>
       <%
          MemInfoDao mdao=new MemInfoDao();
-        String name=mdao.getId(myid);
+        String name=mdao.selectNickById(myid);
         
        
            

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -337,7 +337,7 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 					</tr>
 					<%
 					MemInfoDao mdao = new MemInfoDao();
-					String name = mdao.getId(myid);
+					String name = mdao.selectNickById(myid);
 
 					//게시물이 없는 경우
 					if (totalCount == 0) {

--- a/src/main/webapp/mypage/nickcheck.jsp
+++ b/src/main/webapp/mypage/nickcheck.jsp
@@ -11,10 +11,10 @@ if(!util.SecurityUtil.isPost(request) || !util.SecurityUtil.checkCsrf(request)){
 String m_nick=request.getParameter("m_nick");
 MemInfoDao dao=new MemInfoDao();
 // m_num은 클라이언트 입력 대신 세션 사용자로 고정(임의 m_num으로 타인 닉네임 조회하는 IDOR 차단)
-String m_num=dao.getM_num(util.SecurityUtil.currentId(session));
+String m_num=dao.selectM_num(util.SecurityUtil.currentId(session));
 int count=dao.numPassCheck(m_num, m_nick);
 int nickcount=dao.nickcount(m_nick);
-String nickname=dao.getNick(m_num);
+String nickname=dao.selectNickByNum(m_num);
 
 
 JSONObject ob=new JSONObject();

--- a/src/main/webapp/mypage/updateaction.jsp
+++ b/src/main/webapp/mypage/updateaction.jsp
@@ -59,7 +59,7 @@
 	}
 
 	// 기존 회원 정보(저장된 해시 포함) 조회
-	MemInfoDto current=dao.getAlldatas(myid);
+	MemInfoDto current=dao.selectMemberById(myid);
 
 	// 새 비밀번호가 비어 있으면 기존 해시 유지, 입력되면 새로 해시
 	String finalPass;

--- a/src/main/webapp/mypage/updateform.jsp
+++ b/src/main/webapp/mypage/updateform.jsp
@@ -54,7 +54,7 @@ String loginok = (String) session.getAttribute("loginok");
 String myid = (String) session.getAttribute("myid");
 
 MemInfoDao dao = new MemInfoDao();
-MemInfoDto dto = dao.getAlldatas(myid);
+MemInfoDto dto = dao.selectMemberById(myid);
 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 %>
 <script type="text/javascript">

--- a/src/main/webapp/noticeboard/noticeDetail.jsp
+++ b/src/main/webapp/noticeboard/noticeDetail.jsp
@@ -146,7 +146,7 @@
       
     	  
     	   //아이디 얻기
-    	    String name = rdao.getId(dto.getN_myid());
+    	    String name = rdao.selectNickById(dto.getN_myid());
 
     	  %>
       

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -223,7 +223,7 @@
         	  for(NoticeDto dto:list) {
         	  
         		  //아이디 얻기
-          	       String name = qdao.getId(dto.getN_myid());
+          	       String name = qdao.selectNickById(dto.getN_myid());
         	  %>
         		
         		  <tr>

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -246,7 +246,7 @@
       for(ReviewDto dto:list) {
     	  
     	   //아이디 얻기
-    	    String name = rdao.getId(dto.getR_myid());
+    	    String name = rdao.selectNickById(dto.getR_myid());
 
     	  %>
     	  


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상)의 **회원/인증(meminfo · member · mypage)** 도메인 리팩터. 휴게소(PR #75)와 동일 규칙·강도(full rigor)로 진행. **동작 보존**이 원칙이며 순수 리팩터만 포함.

## 커밋 (작은 단위, 각 단계 javac EXIT=0)
1. `회원 MemInfoDao 위생 정리` — `db` 필드 private화, `// TODO Auto-generated catch block` 제거, Allman/과들여쓰기 → K&R+탭 정규화, 미사용 import(FavoriteDto) 제거
2. `회원 미사용 inputIDGetNick 제거` — 호출처 0건(죽은 코드). 함수명·파라미터(m_id)와 실제 로직(m_num 조회) 불일치였으나 미사용이라 정합 대신 삭제
3. `회원 ResultSet→DTO 매핑 mapRow(rs) 추출` — selectMemberById/selectMemDatas/searchMem의 11컬럼 매핑 중복을 private mapRow로 통합
4. `회원 조회 메서드 get*→select* 통일 + 전 호출처 갱신` — 아래 6개 rename + JSP 호출처 29곳 갱신

## 이름변경 맵
| 기존 | 변경 |
|---|---|
| getAlldatas | selectMemberById |
| getM_num | selectM_num |
| getNick | selectNickByNum |
| getId | selectNickById (실제 닉네임 반환이라 의미 명확화) |
| getRole | selectRole |
| getMemDatas | selectMemDatas |

- 호출처 29곳을 **수신자 타입(MemInfoDao)·인자 유무로 전수 확인** 후 갱신(foodcourt/hugesoinfo/member/mypage/notice·event·review 게시판).
- `dto.getM_num()` 등 **DTO 게터(인자 없음)는 미변경** — DAO 메서드와 이름 충돌 회피.
- 이 환경은 Tomcat/JspC 검증 불가라 JSP는 javac로 안 잡힘 → rename 전후 잔여 호출 grep 0건 재확인.

## 즐겨찾기 결합 — 이연 결정
`getFavlist`/`isFavorite`/`favDelete`가 MemInfoDao에 분산돼 있으나, `FavoriteDao` 신설은 도메인 경계를 넘는 구조 변경이라 **즐겨찾기 도메인 패스로 이연**(이번엔 위생정리만, 이름 유지). JSP를 두 번 건드리지 않기 위함.

## 보안 보존
로그인/회원가입/BCrypt(checkPassword·hashPassword)/passReset/CSRF/권한(role)/예약ID 차단/소유자검증(IDOR 방어 favDelete 2-인자) 모두 **그대로 유지**. searchMem이 mapRow 통합으로 m_pass를 메모리에 로딩하나 membersearch.jsp는 출력하지 않음(확인).

## 검증
- 각 커밋 후 javac 정적검증 EXIT=0.
- 누적 diff에 `/simplify` + `/code-review`(high, recall 편향) 실행 → **correctness 버그 0건**. 제기된 cleanup(select * 좁히기 등)은 기존 코드/동작변경이라 범위 밖으로 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)