### PR TITLE
음식/브랜드 도메인 2단계 리팩터(DAO 위생·mapRow·중복제거·get→select 통일)

### DIFF
--- a/src/main/java/brand/model/BrandDao.java
+++ b/src/main/java/brand/model/BrandDao.java
@@ -100,43 +100,6 @@ public class BrandDao {
 		return total;
 	}
 	
-	//h_num이 일치하는 브랜드정보 출력
-	public List<BrandDto> selectRegisteredBrand(String h_num){
-		List<BrandDto> list=new ArrayList<BrandDto>();
-		
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-		ResultSet rs=null;
-		
-		String sql="select * from brand where h_num=?";
-		
-		try {
-			pstmt=conn.prepareStatement(sql);
-			
-			pstmt.setString(1, h_num);
-			
-			rs=pstmt.executeQuery();
-			
-			while(rs.next()) {
-				BrandDto dto=new BrandDto();
-				
-				dto.setB_num(rs.getString("b_num"));
-				dto.setH_num(rs.getString("h_num"));
-				dto.setB_name(rs.getString("b_name"));
-				dto.setB_photo(rs.getString("b_photo"));
-				dto.setB_addr(rs.getString("b_addr"));
-				
-				list.add(dto);
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-		
-		return list;
-	}
-	
 	//b_num이 일치하는 브랜드 출력
 	public BrandDto getBrandData(String b_num) {
 		BrandDto dto=new BrandDto();

--- a/src/main/java/brand/model/BrandDao.java
+++ b/src/main/java/brand/model/BrandDao.java
@@ -12,7 +12,18 @@ import mysql.db.DbConnect;
 public class BrandDao {
 
 	private DbConnect db=new DbConnect();
-	
+
+	// ResultSet 한 행을 BrandDto로 매핑 (brand 5컬럼 공통)
+	private BrandDto mapRow(ResultSet rs) throws SQLException {
+		BrandDto dto=new BrandDto();
+		dto.setB_num(rs.getString("b_num"));
+		dto.setH_num(rs.getString("h_num"));
+		dto.setB_name(rs.getString("b_name"));
+		dto.setB_photo(rs.getString("b_photo"));
+		dto.setB_addr(rs.getString("b_addr"));
+		return dto;
+	}
+
 	public void insertBrand(BrandDto dto) {
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
@@ -52,15 +63,7 @@ public class BrandDao {
 			rs=pstmt.executeQuery();
 			
 			while(rs.next()) {
-				BrandDto dto=new BrandDto();
-				
-				dto.setB_num(rs.getString("b_num"));
-				dto.setH_num(rs.getString("h_num"));
-				dto.setB_name(rs.getString("b_name"));
-				dto.setB_photo(rs.getString("b_photo"));
-				dto.setB_addr(rs.getString("b_addr"));
-				
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -118,11 +121,7 @@ public class BrandDao {
 			rs=pstmt.executeQuery();
 			
 			if(rs.next()) {
-				dto.setB_num(rs.getString("b_num"));
-				dto.setH_num(rs.getString("h_num"));
-				dto.setB_name(rs.getString("b_name"));
-				dto.setB_photo(rs.getString("b_photo"));
-				dto.setB_addr(rs.getString("b_addr"));
+				dto = mapRow(rs);
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();

--- a/src/main/java/brand/model/BrandDao.java
+++ b/src/main/java/brand/model/BrandDao.java
@@ -75,7 +75,7 @@ public class BrandDao {
 	}
 
 	//h_num이 일치하는 브랜드갯수 출력
-	public int getRegisteredTotal(String h_num) {
+	public int selectRegisteredTotal(String h_num) {
 		int total=0;
 		
 		Connection conn=db.getConnection();
@@ -104,7 +104,7 @@ public class BrandDao {
 	}
 	
 	//b_num이 일치하는 브랜드 출력
-	public BrandDto getBrandData(String b_num) {
+	public BrandDto selectBrandData(String b_num) {
 		BrandDto dto=new BrandDto();
 		
 		Connection conn=db.getConnection();
@@ -157,7 +157,7 @@ public class BrandDao {
 	}
 	
 	//특정 b_num 추출
-	public String getBrandNum(BrandDto dto) {
+	public String selectBrandNum(BrandDto dto) {
 		String b_num="없음";
 		
 		Connection conn=db.getConnection();
@@ -190,7 +190,7 @@ public class BrandDao {
 	}
 	
 	//특정 휴게소 소속 b_num 추출
-	public List<String> getHugesoBrandNum(String h_num){
+	public List<String> selectHugesoBrandNum(String h_num){
 		List<String> list=new ArrayList<String>();
 		
 		Connection conn=db.getConnection();

--- a/src/main/java/brand/model/BrandDao.java
+++ b/src/main/java/brand/model/BrandDao.java
@@ -11,7 +11,7 @@ import mysql.db.DbConnect;
 
 public class BrandDao {
 
-	DbConnect db=new DbConnect();
+	private DbConnect db=new DbConnect();
 	
 	public void insertBrand(BrandDto dto) {
 		Connection conn=db.getConnection();
@@ -29,7 +29,6 @@ public class BrandDao {
 			
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -64,7 +63,6 @@ public class BrandDao {
 				list.add(dto);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -94,7 +92,6 @@ public class BrandDao {
 				total=rs.getInt(1);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -132,7 +129,6 @@ public class BrandDao {
 				list.add(dto);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -166,7 +162,6 @@ public class BrandDao {
 				dto.setB_addr(rs.getString("b_addr"));
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -193,7 +188,6 @@ public class BrandDao {
 			pstmt.execute();
 			
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -225,7 +219,6 @@ public class BrandDao {
 			}
 			
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -255,7 +248,6 @@ public class BrandDao {
 				list.add(rs.getString("b_num"));
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -278,7 +270,6 @@ public class BrandDao {
 			
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -299,7 +290,6 @@ public class BrandDao {
 			
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);

--- a/src/main/java/food/model/FoodDao.java
+++ b/src/main/java/food/model/FoodDao.java
@@ -452,8 +452,7 @@ public class FoodDao {
 		+ "from food\r\n"
 		+ "where f_grade = (select max(f_grade) from food where h_num = ?)\r\n"
 		+ "  and h_num = ?\r\n"
-		+ "limit 1;\r\n"
-		+ "";
+		+ "limit 1;\r\n";
 
 		try {
 			pstmt=conn.prepareStatement(sql);
@@ -462,7 +461,6 @@ public class FoodDao {
 			rs=pstmt.executeQuery();
 
 			if(rs.next()) {
-				/* dto.setH_num(h_num); */
 				String bestFood = rs.getString("f_name");
 				dto.setF_name(bestFood);
 			}

--- a/src/main/java/food/model/FoodDao.java
+++ b/src/main/java/food/model/FoodDao.java
@@ -15,7 +15,19 @@ import mysql.db.DbConnect;
 public class FoodDao {
 
 	private DbConnect db=new DbConnect();
-	
+
+	// ResultSet 한 행을 FoodDto로 매핑 (음식 평점정렬 6컬럼 공통: getFoodLatest/High/Low)
+	private FoodDto mapRow(ResultSet rs) throws SQLException {
+		FoodDto dto = new FoodDto();
+		dto.setF_num(rs.getString("f_num"));
+		dto.setF_name(rs.getString("f_name"));
+		dto.setF_photo(rs.getString("f_photo"));
+		dto.setF_price(rs.getString("f_price"));
+		dto.setH_num(rs.getString("h_num"));
+		dto.setF_grade(rs.getString("f_grade"));
+		return dto;
+	}
+
 	public void insertFood(FoodDto dto) {
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
@@ -362,16 +374,7 @@ public class FoodDao {
 			rs=pstmt.executeQuery();
 
 			while(rs.next()) {
-				FoodDto dto = new FoodDto();
-
-				dto.setF_num(rs.getString("f_num"));
-				dto.setF_name(rs.getString("f_name"));
-				dto.setF_photo(rs.getString("f_photo"));
-				dto.setF_price(rs.getString("f_price"));
-				dto.setH_num(rs.getString("h_num"));
-				dto.setF_grade(rs.getString("f_grade"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -399,16 +402,7 @@ public class FoodDao {
 			rs=pstmt.executeQuery();
 
 			while(rs.next()) {
-				FoodDto dto = new FoodDto();
-
-				dto.setF_num(rs.getString("f_num"));
-				dto.setF_name(rs.getString("f_name"));
-				dto.setF_photo(rs.getString("f_photo"));
-				dto.setF_price(rs.getString("f_price"));
-				dto.setH_num(rs.getString("h_num"));
-				dto.setF_grade(rs.getString("f_grade"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -435,16 +429,7 @@ public class FoodDao {
 			rs=pstmt.executeQuery();
 
 			while(rs.next()) {
-				FoodDto dto = new FoodDto();
-
-				dto.setF_num(rs.getString("f_num"));
-				dto.setF_name(rs.getString("f_name"));
-				dto.setF_photo(rs.getString("f_photo"));
-				dto.setF_price(rs.getString("f_price"));
-				dto.setH_num(rs.getString("h_num"));
-				dto.setF_grade(rs.getString("f_grade"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();

--- a/src/main/java/food/model/FoodDao.java
+++ b/src/main/java/food/model/FoodDao.java
@@ -14,7 +14,7 @@ import mysql.db.DbConnect;
 
 public class FoodDao {
 
-	DbConnect db=new DbConnect();
+	private DbConnect db=new DbConnect();
 	
 	public void insertFood(FoodDto dto) {
 		Connection conn=db.getConnection();
@@ -32,7 +32,6 @@ public class FoodDao {
 			
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -60,7 +59,6 @@ public class FoodDao {
 				total=rs.getInt(1);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -95,15 +93,14 @@ public class FoodDao {
 				list.add(dto);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-			} finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-		
+
 		return list;
 	}
-	
+
 	//f_num이 일치는 음식정보 출력
 	public FoodDto getFoodData(String f_num) {
 		FoodDto dto=new FoodDto();
@@ -129,7 +126,6 @@ public class FoodDao {
 				dto.setF_price(rs.getString("f_price"));
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -155,7 +151,6 @@ public class FoodDao {
 			
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -165,12 +160,12 @@ public class FoodDao {
 	//특정 f_num 추출
 	public String getFoodNum(FoodDto dto) {
 		String f_num="없음";
-    
-    Connection conn=db.getConnection();
+
+		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
 		ResultSet rs=null;
-    
-    String sql="select f_num from food where h_num=? and f_name=? and f_photo=? and f_price=?";
+
+		String sql="select f_num from food where h_num=? and f_name=? and f_photo=? and f_price=?";
 		
 		try {
 			pstmt=conn.prepareStatement(sql);
@@ -179,14 +174,13 @@ public class FoodDao {
 			pstmt.setString(2, dto.getF_name());
 			pstmt.setString(3, dto.getF_photo());
 			pstmt.setString(4, dto.getF_price());
-      
-      rs=pstmt.executeQuery();
-			
+
+			rs=pstmt.executeQuery();
+
 			if(rs.next()) {
 				f_num=rs.getString("f_num");
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -216,7 +210,6 @@ public class FoodDao {
 				list.add(rs.getString("f_num"));
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -239,7 +232,6 @@ public class FoodDao {
 			
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -260,7 +252,6 @@ public class FoodDao {
 			
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -297,7 +288,6 @@ public class FoodDao {
 				list.add(dto);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -325,7 +315,6 @@ public class FoodDao {
 				f_num=rs.getString("f_num");
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(rs, pstmt, conn);
@@ -334,40 +323,39 @@ public class FoodDao {
 	}
 	
 	//승경_메인화면에 메뉴 번호순서대로 가져오기 위해 생성
-    public List<FoodDto> getAllFood(){
-       List<FoodDto> foodlist = new ArrayList<FoodDto>();
-       
-       Connection conn = db.getConnection();
-       PreparedStatement pstmt = null;
-       ResultSet rs = null;
-       
-       String sql ="select * from food order by f_num desc";
-       
-       try {
-          pstmt = conn.prepareStatement(sql);
-          rs=pstmt.executeQuery();
-          
-          while(rs.next()) {
-        	  FoodDto dto = new FoodDto();
-             
-        	  dto.setF_num(rs.getString("f_num"));
+	public List<FoodDto> getAllFood(){
+		List<FoodDto> foodlist = new ArrayList<FoodDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql ="select * from food order by f_num desc";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs=pstmt.executeQuery();
+
+			while(rs.next()) {
+				FoodDto dto = new FoodDto();
+
+				dto.setF_num(rs.getString("f_num"));
 				dto.setF_name(rs.getString("f_name"));
 				dto.setF_photo(rs.getString("f_photo"));
 				dto.setF_price(rs.getString("f_price"));
-             
-             
+
+
 				foodlist.add(dto);
-          }
-          
-       } catch (SQLException e) {
-          // TODO Auto-generated catch block
-          e.printStackTrace();
-       }finally {
-          db.dbClose(rs, pstmt, conn);
-       }
-          return foodlist;
-          
-    }
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+		return foodlist;
+
+	}
 
 	// 음식 평균 평점 update (hugesodetail.jsp)
 	public void updateF_grade(FoodDto dto) {
@@ -393,146 +381,146 @@ public class FoodDao {
 	
 	
 	//음식 평점 정렬 (hugesodetail.jsp)
-		public List<FoodDto> getFoodLatest(String h_num){
-			List<FoodDto> list = new ArrayList<FoodDto>();
-					
-					Connection conn = db.getConnection();
-					PreparedStatement pstmt = null;
-					ResultSet rs = null;
-					
-					String sql = "select * from food where h_num =? order by f_num";
-					
-					try {
-						pstmt=conn.prepareStatement(sql);
-						pstmt.setString(1, h_num);
-						rs=pstmt.executeQuery();
-						
-						while(rs.next()) {
-							FoodDto dto = new FoodDto();
-							
-							dto.setF_num(rs.getString("f_num"));
-							dto.setF_name(rs.getString("f_name"));
-							dto.setF_photo(rs.getString("f_photo"));
-							dto.setF_price(rs.getString("f_price"));
-							dto.setH_num(rs.getString("h_num"));
-							dto.setF_grade(rs.getString("f_grade"));
-							
-							list.add(dto);
-						}
-					} catch (SQLException e) {
-						e.printStackTrace();
-					}finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-					
-					return list;
-				}
-	
-	
+	public List<FoodDto> getFoodLatest(String h_num){
+		List<FoodDto> list = new ArrayList<FoodDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from food where h_num =? order by f_num";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			pstmt.setString(1, h_num);
+			rs=pstmt.executeQuery();
+
+			while(rs.next()) {
+				FoodDto dto = new FoodDto();
+
+				dto.setF_num(rs.getString("f_num"));
+				dto.setF_name(rs.getString("f_name"));
+				dto.setF_photo(rs.getString("f_photo"));
+				dto.setF_price(rs.getString("f_price"));
+				dto.setH_num(rs.getString("h_num"));
+				dto.setF_grade(rs.getString("f_grade"));
+
+				list.add(dto);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return list;
+	}
+
+
 	//음식 평점 정렬(평점높은순) (hugesodetail.jsp)
 	public List<FoodDto> getFoodHigh(String h_num){
 		List<FoodDto> list = new ArrayList<FoodDto>();
-				
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				ResultSet rs = null;
-				
-				String sql = "select * from food where h_num =? order by f_grade desc";
-				
-				try {
-					pstmt=conn.prepareStatement(sql);
-					pstmt.setString(1, h_num);
-					rs=pstmt.executeQuery();
-					
-					while(rs.next()) {
-						FoodDto dto = new FoodDto();
-						
-						dto.setF_num(rs.getString("f_num"));
-						dto.setF_name(rs.getString("f_name"));
-						dto.setF_photo(rs.getString("f_photo"));
-						dto.setF_price(rs.getString("f_price"));
-						dto.setH_num(rs.getString("h_num"));
-						dto.setF_grade(rs.getString("f_grade"));
-						
-						list.add(dto);
-					}
-				} catch (SQLException e) {
-					e.printStackTrace();
-				}finally {
-					db.dbClose(rs, pstmt, conn);
-				}
-				
-				return list;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from food where h_num =? order by f_grade desc";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			pstmt.setString(1, h_num);
+			rs=pstmt.executeQuery();
+
+			while(rs.next()) {
+				FoodDto dto = new FoodDto();
+
+				dto.setF_num(rs.getString("f_num"));
+				dto.setF_name(rs.getString("f_name"));
+				dto.setF_photo(rs.getString("f_photo"));
+				dto.setF_price(rs.getString("f_price"));
+				dto.setH_num(rs.getString("h_num"));
+				dto.setF_grade(rs.getString("f_grade"));
+
+				list.add(dto);
 			}
-			
-			//음식 평점 정렬(평점낮은순) (hugesodetail.jsp)
-				public List<FoodDto> getFoodLow(String h_num){
-					List<FoodDto> list = new ArrayList<FoodDto>();
-					
-					Connection conn = db.getConnection();
-					PreparedStatement pstmt = null;
-					ResultSet rs = null;
-					
-					String sql = "select * from food where h_num =? order by f_grade asc";
-					
-					try {
-						pstmt=conn.prepareStatement(sql);
-						pstmt.setString(1, h_num);
-						rs=pstmt.executeQuery();
-						
-						while(rs.next()) {
-							FoodDto dto = new FoodDto();
-							
-							dto.setF_num(rs.getString("f_num"));
-							dto.setF_name(rs.getString("f_name"));
-							dto.setF_photo(rs.getString("f_photo"));
-							dto.setF_price(rs.getString("f_price"));
-							dto.setH_num(rs.getString("h_num"));
-							dto.setF_grade(rs.getString("f_grade"));
-							
-							list.add(dto);
-						}
-					} catch (SQLException e) {
-						e.printStackTrace();
-					}finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-					
-					return list;
-				}
-				
-				// 해당 휴게소에서 평점이 가장 높은 음식 이름 하나만 출력 (hugesodetail.jsp)
-				public FoodDto bestFood(String h_num) {
-				    FoodDto dto = new FoodDto();
-				    
-				    Connection conn = db.getConnection();
-				    PreparedStatement pstmt=null;
-				    ResultSet rs = null;
-				    
-				    String sql ="select f_name\r\n"
-				    		+ "from food\r\n"
-				    		+ "where f_grade = (select max(f_grade) from food where h_num = ?)\r\n"
-				    		+ "  and h_num = ?\r\n"
-				    		+ "limit 1;\r\n"
-				    		+ "";
-				    
-				    try {
-				        pstmt=conn.prepareStatement(sql);
-				        pstmt.setString(1, h_num);
-				        pstmt.setString(2, h_num);
-				        rs=pstmt.executeQuery();
-				        
-				        if(rs.next()) {
-							/* dto.setH_num(h_num); */
-				        	String bestFood = rs.getString("f_name");
-				            dto.setF_name(bestFood); 
-				        }
-				    } catch (SQLException e) {
-				        e.printStackTrace();
-				    }finally {
-				        db.dbClose(rs, pstmt, conn);
-				    }    
-				    return dto;
-				}
-				
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return list;
+	}
+
+	//음식 평점 정렬(평점낮은순) (hugesodetail.jsp)
+	public List<FoodDto> getFoodLow(String h_num){
+		List<FoodDto> list = new ArrayList<FoodDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from food where h_num =? order by f_grade asc";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			pstmt.setString(1, h_num);
+			rs=pstmt.executeQuery();
+
+			while(rs.next()) {
+				FoodDto dto = new FoodDto();
+
+				dto.setF_num(rs.getString("f_num"));
+				dto.setF_name(rs.getString("f_name"));
+				dto.setF_photo(rs.getString("f_photo"));
+				dto.setF_price(rs.getString("f_price"));
+				dto.setH_num(rs.getString("h_num"));
+				dto.setF_grade(rs.getString("f_grade"));
+
+				list.add(dto);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return list;
+	}
+
+	// 해당 휴게소에서 평점이 가장 높은 음식 이름 하나만 출력 (hugesodetail.jsp)
+	public FoodDto bestFood(String h_num) {
+		FoodDto dto = new FoodDto();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt=null;
+		ResultSet rs = null;
+
+		String sql ="select f_name\r\n"
+		+ "from food\r\n"
+		+ "where f_grade = (select max(f_grade) from food where h_num = ?)\r\n"
+		+ "  and h_num = ?\r\n"
+		+ "limit 1;\r\n"
+		+ "";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			pstmt.setString(1, h_num);
+			pstmt.setString(2, h_num);
+			rs=pstmt.executeQuery();
+
+			if(rs.next()) {
+				/* dto.setH_num(h_num); */
+				String bestFood = rs.getString("f_name");
+				dto.setF_name(bestFood);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+		return dto;
+	}
+
 }

--- a/src/main/java/food/model/FoodDao.java
+++ b/src/main/java/food/model/FoodDao.java
@@ -67,40 +67,6 @@ public class FoodDao {
 		return total;
 	}
 	
-	//유지)) 휴게소별 메뉴판 구현을 위해서 작성
-	public List<FoodDto> getMenu(String h_num){
-		List<FoodDto> list=new ArrayList<FoodDto>();
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-		ResultSet rs=null;
-		
-		String sql="select * from food where h_num=?";
-    
-		try {
-			pstmt=conn.prepareStatement(sql);
-			pstmt.setString(1, h_num);
-			rs=pstmt.executeQuery();
-			
-			while(rs.next()) {
-				FoodDto dto=new FoodDto();
-        
-				dto.setF_num(rs.getString("f_num"));
-				dto.setF_name(rs.getString("f_name"));
-				dto.setF_photo(rs.getString("f_photo"));
-				dto.setF_price(rs.getString("f_price"));
-				dto.setH_num(rs.getString("h_num"));
-				
-				list.add(dto);
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-
-		return list;
-	}
-
 	//f_num이 일치는 음식정보 출력
 	public FoodDto getFoodData(String f_num) {
 		FoodDto dto=new FoodDto();

--- a/src/main/java/food/model/FoodDao.java
+++ b/src/main/java/food/model/FoodDao.java
@@ -16,7 +16,7 @@ public class FoodDao {
 
 	private DbConnect db=new DbConnect();
 
-	// ResultSet 한 행을 FoodDto로 매핑 (음식 평점정렬 6컬럼 공통: getFoodLatest/High/Low)
+	// ResultSet 한 행을 FoodDto로 매핑 (음식 평점정렬 6컬럼 공통: selectFoodLatest/High/Low)
 	private FoodDto mapRow(ResultSet rs) throws SQLException {
 		FoodDto dto = new FoodDto();
 		dto.setF_num(rs.getString("f_num"));
@@ -51,7 +51,7 @@ public class FoodDao {
 	}
 	
 	//h_num이 일치하는 음식갯수 출력
-	public int getRegisteredTotal(String h_num) {
+	public int selectRegisteredTotal(String h_num) {
 		int total=0;
 		
 		Connection conn=db.getConnection();
@@ -80,7 +80,7 @@ public class FoodDao {
 	}
 	
 	//f_num이 일치는 음식정보 출력
-	public FoodDto getFoodData(String f_num) {
+	public FoodDto selectFoodData(String f_num) {
 		FoodDto dto=new FoodDto();
 		
 		Connection conn=db.getConnection();
@@ -136,7 +136,7 @@ public class FoodDao {
 	}
 	
 	//특정 f_num 추출
-	public String getFoodNum(FoodDto dto) {
+	public String selectFoodNum(FoodDto dto) {
 		String f_num="없음";
 
 		Connection conn=db.getConnection();
@@ -168,7 +168,7 @@ public class FoodDao {
 	}
 	
 	//특정 휴게소 소속 f_num 추출
-	public List<String> getHugesoFoodNum(String h_num){
+	public List<String> selectHugesoFoodNum(String h_num){
 		List<String> list=new ArrayList<String>();
 		
 		Connection conn=db.getConnection();
@@ -275,7 +275,7 @@ public class FoodDao {
 	}
   
   //유지)) f_num을 얻기위해서 h_num과 f_name사용
-	public String getF_num(String h_num, String f_name) {
+	public String selectF_num(String h_num, String f_name) {
 		String f_num="";
     
 		Connection conn=db.getConnection();
@@ -301,7 +301,7 @@ public class FoodDao {
 	}
 	
 	//승경_메인화면에 메뉴 번호순서대로 가져오기 위해 생성
-	public List<FoodDto> getAllFood(){
+	public List<FoodDto> selectAllFood(){
 		List<FoodDto> foodlist = new ArrayList<FoodDto>();
 
 		Connection conn = db.getConnection();
@@ -359,7 +359,7 @@ public class FoodDao {
 	
 	
 	//음식 평점 정렬 (hugesodetail.jsp)
-	public List<FoodDto> getFoodLatest(String h_num){
+	public List<FoodDto> selectFoodLatest(String h_num){
 		List<FoodDto> list = new ArrayList<FoodDto>();
 
 		Connection conn = db.getConnection();
@@ -387,7 +387,7 @@ public class FoodDao {
 
 
 	//음식 평점 정렬(평점높은순) (hugesodetail.jsp)
-	public List<FoodDto> getFoodHigh(String h_num){
+	public List<FoodDto> selectFoodHigh(String h_num){
 		List<FoodDto> list = new ArrayList<FoodDto>();
 
 		Connection conn = db.getConnection();
@@ -414,7 +414,7 @@ public class FoodDao {
 	}
 
 	//음식 평점 정렬(평점낮은순) (hugesodetail.jsp)
-	public List<FoodDto> getFoodLow(String h_num){
+	public List<FoodDto> selectFoodLow(String h_num){
 		List<FoodDto> list = new ArrayList<FoodDto>();
 
 		Connection conn = db.getConnection();
@@ -441,7 +441,7 @@ public class FoodDao {
 	}
 
 	// 해당 휴게소에서 평점이 가장 높은 음식 이름 하나만 출력 (hugesodetail.jsp)
-	public FoodDto bestFood(String h_num) {
+	public FoodDto selectBestFood(String h_num) {
 		FoodDto dto = new FoodDto();
 
 		Connection conn = db.getConnection();

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -226,7 +226,7 @@ String m_id=(String)session.getAttribute("myid");
 
 //food메뉴 가져오기
 FoodDao dao=new FoodDao();
-List<FoodDto> list=dao.getMenu(h_num);
+List<FoodDto> list=dao.selectFood(h_num);
 //로그인했을때 해당아이디로 주문한 메뉴 보이게
 MemInfoDao mdao=new MemInfoDao();
 String m_num=mdao.selectM_num(m_id);

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -251,7 +251,7 @@ NumberFormat nf=NumberFormat.getInstance();
 <%
 	for(int i=0;i<list.size();i++){
 		FoodDto dto=list.get(i); 
-		String f_num=dao.getF_num(h_num, dto.getF_name());
+		String f_num=dao.selectF_num(h_num, dto.getF_name());
 
 		int pr=Integer.parseInt(dto.getF_price());
 		%>

--- a/src/main/webapp/foodgrade/foodgradesort.jsp
+++ b/src/main/webapp/foodgrade/foodgradesort.jsp
@@ -16,14 +16,14 @@
 
     // 정렬 유형에 따라 적절한 메서드를 호출하여 평점 목록을 가져옴
     if (sortType.equals("latest")) {
-        list = dao.getFoodLatest(h_num);
+        list = dao.selectFoodLatest(h_num);
     } else if (sortType.equals("high")) {
-        list = dao.getFoodHigh(h_num);
+        list = dao.selectFoodHigh(h_num);
     } else if (sortType.equals("low")) {
-        list = dao.getFoodLow(h_num);
+        list = dao.selectFoodLow(h_num);
     } else {
         // 기본적으로 최신순으로 정렬
-        list = dao.getFoodLatest(h_num);
+        list = dao.selectFoodLatest(h_num);
     }
 
     // HTML 생성을 위한 문자열

--- a/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
@@ -26,7 +26,7 @@
 	for(int i=0;i<blist.size();i++){
 		bdto=blist.get(i);
 		
-		String filePath=uploadPath+"/"+bdao.getBrandData(bdto.getB_num()).getB_photo();
+		String filePath=uploadPath+"/"+bdao.selectBrandData(bdto.getB_num()).getB_photo();
 		File file=new File(filePath);
 		if(file.exists()){
 			file.delete();

--- a/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
@@ -43,7 +43,7 @@
 	for(int i=0;i<flist.size();i++){
 		fdto=flist.get(i);
 		
-		String filePath=uploadPath+"/"+fdao.getFoodData(fdto.getF_num()).getF_photo();
+		String filePath=uploadPath+"/"+fdao.selectFoodData(fdto.getF_num()).getF_photo();
 		File file=new File(filePath);
 		if(file.exists()){
 			file.delete();

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -63,7 +63,7 @@
 	
 	//FoodDao 객체 생성 & 음식 데이터 가져오기
 	FoodDao fdao = new FoodDao();
-	FoodDto ffdto = fdao.bestFood(h_num);
+	FoodDto ffdto = fdao.selectBestFood(h_num);
 	List<FoodDto> foodlist = fdao.selectFood(h_num);
 	
 	//BrandDao 객체 생성 & 브랜드 데이터 가져오기

--- a/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
@@ -205,13 +205,13 @@
 					
 					fdao.insertFood(fdto);
 					
-					numList.add(fdao.getFoodNum(fdto));
+					numList.add(fdao.selectFoodNum(fdto));
 				} else{
 					fdto.setF_num(f_num);
 					String f_name = multi.getParameter("f_name"+i);
 					fdto.setF_name(f_name);
 					String f_photo = multi.getFilesystemName("f_photo"+i);
-					String oldPhoto=fdao.getFoodData(f_num).getF_photo();
+					String oldPhoto=fdao.selectFoodData(f_num).getF_photo();
 					if(f_photo==null){
 				    	fdto.setF_photo(oldPhoto);
 				    }else{
@@ -231,7 +231,7 @@
 					numList.add(f_num);
 				}
 			}
-			List<String> hugesoFoodList=fdao.getHugesoFoodNum(h_num);
+			List<String> hugesoFoodList=fdao.selectHugesoFoodNum(h_num);
 			for(int i=0;i<hugesoFoodList.size();i++){
 				String f_num=hugesoFoodList.get(i);
 				boolean flag=true;
@@ -242,7 +242,7 @@
 				}
 				if(flag){
 					//파일삭제
-					String filePath=uploadPath+"/"+fdao.getFoodData(f_num).getF_photo();
+					String filePath=uploadPath+"/"+fdao.selectFoodData(f_num).getF_photo();
 					File file=new File(filePath);
 					if(file.exists()){
 						file.delete();
@@ -258,7 +258,7 @@
 			for(int i=0;i<flist.size();i++){
 				fdto=flist.get(i);
 				
-				String filePath=uploadPath+"/"+fdao.getFoodData(fdto.getF_num()).getF_photo();
+				String filePath=uploadPath+"/"+fdao.selectFoodData(fdto.getF_num()).getF_photo();
 				File file=new File(filePath);
 				if(file.exists()){
 					file.delete();

--- a/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateaction.jsp
@@ -122,13 +122,13 @@
 					
 					bdao.insertBrand(bdto);
 					
-					numList.add(bdao.getBrandNum(bdto));
+					numList.add(bdao.selectBrandNum(bdto));
 				} else{
 					bdto.setB_num(b_num);
 					String b_name = multi.getParameter("b_name"+i);
 					bdto.setB_name(b_name);
 					String b_photo = multi.getFilesystemName("b_photo"+i);
-					String oldPhoto=bdao.getBrandData(b_num).getB_photo();
+					String oldPhoto=bdao.selectBrandData(b_num).getB_photo();
 					if(b_photo==null){
 				    	bdto.setB_photo(oldPhoto);
 				    }else{
@@ -148,7 +148,7 @@
 					numList.add(b_num);
 				}
 			}
-			List<String> hugesoBrandList=bdao.getHugesoBrandNum(h_num);
+			List<String> hugesoBrandList=bdao.selectHugesoBrandNum(h_num);
 			for(int i=0;i<hugesoBrandList.size();i++){
 				String b_num=hugesoBrandList.get(i);
 				boolean flag=true;
@@ -159,7 +159,7 @@
 				}
 				if(flag){
 					//파일삭제
-					String filePath=uploadPath+"/"+bdao.getBrandData(b_num).getB_photo();
+					String filePath=uploadPath+"/"+bdao.selectBrandData(b_num).getB_photo();
 					File file=new File(filePath);
 					if(file.exists()){
 						file.delete();
@@ -175,7 +175,7 @@
 			for(int i=0;i<blist.size();i++){
 				bdto=blist.get(i);
 				
-				String filePath=uploadPath+"/"+bdao.getBrandData(bdto.getB_num()).getB_photo();
+				String filePath=uploadPath+"/"+bdao.selectBrandData(bdto.getB_num()).getB_photo();
 				File file=new File(filePath);
 				if(file.exists()){
 					file.delete();

--- a/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
@@ -36,7 +36,7 @@
     List<BrandDto> blist=bdao.selectBrand(h_num);
     
     FoodDao fdao=new FoodDao();
-    int ftotal=fdao.getRegisteredTotal(h_num);
+    int ftotal=fdao.selectRegisteredTotal(h_num);
     List<FoodDto> flist=fdao.selectFood(h_num);
 %>
 	<style type="text/css">

--- a/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
@@ -32,7 +32,7 @@
     String[] pyeonArray = pyeons.split(","); //콤마를 기준으로 편의시설 문자열을 분리하여 배열 pyeonArray에 넣어줌
     
     BrandDao bdao=new BrandDao();
-    int btotal=bdao.getRegisteredTotal(h_num);
+    int btotal=bdao.selectRegisteredTotal(h_num);
     List<BrandDto> blist=bdao.selectBrand(h_num);
     
     FoodDao fdao=new FoodDao();

--- a/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
@@ -37,7 +37,7 @@
     
     FoodDao fdao=new FoodDao();
     int ftotal=fdao.getRegisteredTotal(h_num);
-    List<FoodDto> flist=fdao.getMenu(h_num);
+    List<FoodDto> flist=fdao.selectFood(h_num);
 %>
 	<style type="text/css">
 		#area{

--- a/src/main/webapp/mainlayout/foodrank.jsp
+++ b/src/main/webapp/mainlayout/foodrank.jsp
@@ -108,7 +108,7 @@
 <div class="swiper-container menu">
     <div class="swiper-wrapper">
         <% 
-            List<FoodDto> recentfood = fdao.getAllFood();
+            List<FoodDto> recentfood = fdao.selectAllFood();
             int size = Math.min(recentfood.size(), 5);
             for (int f = 0; f < size; f++) { 
             	FoodDto dto = recentfood.get(f); 

--- a/src/main/webapp/mainlayout/foodrank.jsp
+++ b/src/main/webapp/mainlayout/foodrank.jsp
@@ -98,7 +98,6 @@
 
    //휴게소
    FoodDao fdao = new FoodDao();
-   List<FoodDto> hlist = fdao.getAllFood();
 
 	NumberFormat nf=NumberFormat.getInstance();
 %>


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화·유지보수성) 리팩터링의 **음식/브랜드(food·brand)** 도메인 작업이다.
회원(#76)·휴게소(#75)·평점(#77)과 동일한 규칙·강도로, **동작을 100% 보존**하면서 DAO 위생·중복/죽은 코드 제거·`mapRow` 추출·조회 메서드 `get*→select*` 접두어 통일을 작은 커밋으로 적용했다.

## 변경 내용

### 브랜드 (BrandDao)
- 위생: `db` 필드 `private`화, `// TODO Auto-generated catch block` 노이즈 주석 제거
- 죽은 코드: 호출처 0건인 `selectRegisteredBrand` 제거(쿼리·매핑이 `selectBrand`와 100% 동일한 중복)
- `mapRow(rs)` 추출: `selectBrand`·`selectBrandData` 공통 5컬럼(`b_num·h_num·b_name·b_photo·b_addr`)
- `get*→select*` 통일: `selectRegisteredTotal`/`selectBrandData`/`selectBrandNum`/`selectHugesoBrandNum` + 호출처 갱신

### 음식 (FoodDao)
- 위생: `db` 필드 `private`화, TODO 주석 12개 제거, 들여쓰기 깊이 불일치 정정(brace 깊이 기준 재정렬, `git diff -w`로 토큰 변경 0건 확인 — SQL·로직 불변)
- 중복 통합: `getMenu` 제거 → 호출처 2곳을 `selectFood`로 갱신(동일 쿼리, 호출처가 상대 전용 컬럼 미사용임을 전수 검증)
- `mapRow(rs)` 추출: `selectFoodLatest`/`High`/`Low` 공통 6컬럼. 컬럼셋이 다른 `selectFood`·`selectFoodData`·`selectAllFood`는 동작 변경 방지를 위해 통합 제외(인라인 유지)
- `get*/동사명→select*` 통일: `selectRegisteredTotal`/`selectFoodData`/`selectFoodNum`/`selectHugesoFoodNum`/`selectF_num`/`selectAllFood`/`selectFoodLatest·High·Low`/`selectBestFood` + 전 호출처 갱신
- 죽은 코드(/simplify): `selectBestFood`의 무의미한 `+ ""` 연결·주석처리 줄 제거

### 기타
- `mainlayout/foodrank.jsp`: 대입만 되고 미사용인 `hlist` 변수 제거(불필요한 전체조회 1회도 함께 제거)

## 검증
- **javac EXIT=0**: 매 커밋마다 `FoodDao`/`BrandDao` 컴파일 검증(servlet-api 4.0.1 + `WEB-INF/lib`)
- **JSP 호출처 전수 grep**: 옛 DAO 메서드명 잔존 0건, 수신자 타입(`fdao`/`bdao`/`dao`)·인자수 확인. 특히 `getRegisteredTotal`은 Food/Brand 동명이라 수신자별로 구분, 0-인자 DTO 게터 `getF_num()`/`getB_num()`는 미변경
- **/simplify + /code-review(high)**: 품질 정리 1건 반영, 버그 0건

## 보존(약화 없음)
업로드 파일 경로 처리·검증(`SecurityUtil.validateOrDelete`/`validateAllUploads`)·`ImageServlet`(/fileview) 경유·관리자 role·CSRF·isPost 가드, `foodgradesort.jsp`의 JSON `escapeHtml`(DOM XSS 방어) 모두 유지. `printStackTrace`→로거 전환은 2단계 범위 밖이라 미변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
