### PR TITLE
푸드코트 장바구니 도메인 2단계 리팩터(DAO 위생·죽은코드 제거·get→select 통일·N+1 제거·패키지 이동)

### DIFF
--- a/src/main/java/food/model/FoodDao.java
+++ b/src/main/java/food/model/FoodDao.java
@@ -273,33 +273,7 @@ public class FoodDao {
 		
 		return list;
 	}
-  
-  //유지)) f_num을 얻기위해서 h_num과 f_name사용
-	public String selectF_num(String h_num, String f_name) {
-		String f_num="";
-    
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-		ResultSet rs=null;
-		
-		String sql="select f_num from food where h_num=? and f_name=?";
-		try {
-			pstmt=conn.prepareStatement(sql);
-			pstmt.setString(1, h_num);
-			pstmt.setString(2, f_name);
-			rs=pstmt.executeQuery();
-			
-			if(rs.next()) {
-				f_num=rs.getString("f_num");
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		}finally {
-			db.dbClose(rs, pstmt, conn);
-		}	
-		return f_num;
-	}
-	
+
 	//승경_메인화면에 메뉴 번호순서대로 가져오기 위해 생성
 	public List<FoodDto> selectAllFood(){
 		List<FoodDto> foodlist = new ArrayList<FoodDto>();

--- a/src/main/java/foodcart/FoodCartDao.java
+++ b/src/main/java/foodcart/FoodCartDao.java
@@ -34,7 +34,7 @@ public class FoodCartDao {
 	}
 	
 	//유지))장바구니에 중복된 메뉴가 들어있는지 확인
-	public boolean getCartCnt(String f_num, String m_num) {
+	public boolean selectCartItemExists(String f_num, String m_num) {
 		boolean c=false;
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;
@@ -78,7 +78,7 @@ public class FoodCartDao {
 	}
 	
 	//유지))아이디로 주문목록 출력
-	public List<HashMap<String, String>> getCartMenu(String m_num,String h_num){
+	public List<HashMap<String, String>> selectCartMenu(String m_num,String h_num){
 		List<HashMap<String, String>> list=new ArrayList<HashMap<String,String>>();
 		Connection conn=db.getConnection();
 		PreparedStatement pstmt=null;

--- a/src/main/java/foodcart/FoodCartDao.java
+++ b/src/main/java/foodcart/FoodCartDao.java
@@ -124,30 +124,6 @@ public class FoodCartDao {
 		}
 	}
 	
-	//유지))부분취소를 위한 idx를 구하기
-	public FoodCartDto getIdx(String f_num, String m_num) {
-		FoodCartDto dto=new FoodCartDto();
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-		ResultSet rs=null;
-		String sql="select cart_idx from foodcart where f_num=? and m_num=?";
-		try {
-			pstmt=conn.prepareStatement(sql);
-			pstmt.setString(1, f_num);
-			pstmt.setString(2, m_num);
-			rs=pstmt.executeQuery();
-			if(rs.next()) {
-				dto.setCart_idx(rs.getString("cart_idx"));
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		}finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-		
-		return dto;
-	}
-	
 	//유지))결제완료 후에는 모든 cart를 비워야한다. m_num을 기준으로 비워보자, 카트 전체삭제
 	public void deleteAllCart(String m_num) {
 		Connection conn=db.getConnection();

--- a/src/main/java/foodcart/FoodCartDao.java
+++ b/src/main/java/foodcart/FoodCartDao.java
@@ -11,7 +11,7 @@ import java.util.List;
 import mysql.db.DbConnect;
 
 public class FoodCartDao {
-	DbConnect db=new DbConnect();
+	private DbConnect db=new DbConnect();
 	
 	//음식 카트에 추가
 	public void insertFoodCart(FoodCartDto dto) {
@@ -27,7 +27,6 @@ public class FoodCartDao {
 			pstmt.setInt(4, dto.getCart_cnt());
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(pstmt, conn);
@@ -51,7 +50,6 @@ public class FoodCartDao {
 				c=true;
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(rs, pstmt, conn);
@@ -73,7 +71,6 @@ public class FoodCartDao {
 			pstmt.setString(2, dto.getM_num());
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(pstmt, conn);
@@ -103,7 +100,6 @@ public class FoodCartDao {
 				list.add(map);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(rs, pstmt, conn);
@@ -122,7 +118,6 @@ public class FoodCartDao {
 			pstmt.setString(2, m_num);
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(pstmt, conn);
@@ -145,7 +140,6 @@ public class FoodCartDao {
 				dto.setCart_idx(rs.getString("cart_idx"));
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(rs, pstmt, conn);
@@ -164,7 +158,6 @@ public class FoodCartDao {
 			pstmt.setString(1, m_num);
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}finally {
 			db.dbClose(pstmt, conn);

--- a/src/main/java/foodcart/model/FoodCartDao.java
+++ b/src/main/java/foodcart/model/FoodCartDao.java
@@ -1,4 +1,4 @@
-package foodcart;
+package foodcart.model;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/src/main/java/foodcart/model/FoodCartDto.java
+++ b/src/main/java/foodcart/model/FoodCartDto.java
@@ -1,4 +1,4 @@
-package foodcart;
+package foodcart.model;
 
 import java.sql.Timestamp;
 

--- a/src/main/webapp/foodcourt/cartalldelete.jsp
+++ b/src/main/webapp/foodcourt/cartalldelete.jsp
@@ -1,4 +1,4 @@
-<%@page import="foodcart.FoodCartDao"%>
+<%@page import="foodcart.model.FoodCartDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%

--- a/src/main/webapp/foodcourt/foodcartaddaction.jsp
+++ b/src/main/webapp/foodcourt/foodcartaddaction.jsp
@@ -25,7 +25,7 @@ String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.curren
 int cart_cnt=Integer.parseInt(request.getParameter("cart_cnt"));
 
 FoodCartDao dao=new FoodCartDao();
-boolean cnt=dao.getCartCnt(f_num, m_num);
+boolean cnt=dao.selectCartItemExists(f_num, m_num);
 
 if(cnt){
 	FoodCartDto dto=new FoodCartDto();

--- a/src/main/webapp/foodcourt/foodcartaddaction.jsp
+++ b/src/main/webapp/foodcourt/foodcartaddaction.jsp
@@ -1,5 +1,5 @@
-<%@page import="foodcart.FoodCartDto"%>
-<%@page import="foodcart.FoodCartDao"%>
+<%@page import="foodcart.model.FoodCartDto"%>
+<%@page import="foodcart.model.FoodCartDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <!DOCTYPE html>

--- a/src/main/webapp/foodcourt/foodcartaddaction.jsp
+++ b/src/main/webapp/foodcourt/foodcartaddaction.jsp
@@ -9,7 +9,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Grandiflora+One&family=Gugi&family=Hahmlet:wght@100..900&family=Hi+Melody&family=Sunflower:wght@300&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>장바구니 담기</title>
 </head>
 <body>
 <%

--- a/src/main/webapp/foodcourt/foodcartdelete.jsp
+++ b/src/main/webapp/foodcourt/foodcartdelete.jsp
@@ -1,4 +1,4 @@
-<%@page import="foodcart.FoodCartDao"%>
+<%@page import="foodcart.model.FoodCartDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%

--- a/src/main/webapp/foodcourt/foodcartlist.jsp
+++ b/src/main/webapp/foodcourt/foodcartlist.jsp
@@ -15,7 +15,7 @@ String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.curren
 String h_num=request.getParameter("h_num");
 
 FoodCartDao dao=new FoodCartDao();
-List<HashMap<String,String>> list=dao.getCartMenu(m_num, h_num);
+List<HashMap<String,String>> list=dao.selectCartMenu(m_num, h_num);
 
 JSONArray arr=new JSONArray();
 

--- a/src/main/webapp/foodcourt/foodcartlist.jsp
+++ b/src/main/webapp/foodcourt/foodcartlist.jsp
@@ -2,7 +2,7 @@
 <%@page import="org.json.simple.JSONArray"%>
 <%@page import="java.util.HashMap"%>
 <%@page import="java.util.List"%>
-<%@page import="foodcart.FoodCartDao"%>
+<%@page import="foodcart.model.FoodCartDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -273,7 +273,7 @@ NumberFormat nf=NumberFormat.getInstance();
 
 <%
 FoodCartDao cdao=new FoodCartDao();
-List<HashMap<String,String>> clist=cdao.getCartMenu(m_num, h_num);
+List<HashMap<String,String>> clist=cdao.selectCartMenu(m_num, h_num);
 MemInfoDto dto=mdao.selectMemberById(m_id);
 
 %>

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -3,8 +3,7 @@
 <%@page import="meminfo.model.MemInfoDto"%>
 <%@page import="java.text.NumberFormat"%>
 <%@page import="java.util.HashMap"%>
-<%@page import="foodcart.FoodCartDto"%>
-<%@page import="foodcart.FoodCartDao"%>
+<%@page import="foodcart.model.FoodCartDao"%>
 <%@page import="meminfo.model.MemInfoDao"%>
 <%@page import="food.model.FoodDto"%>
 <%@page import="java.util.List"%>

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -249,8 +249,8 @@ NumberFormat nf=NumberFormat.getInstance();
 <div align="center" id="foodmenu" >
 <%
 	for(int i=0;i<list.size();i++){
-		FoodDto dto=list.get(i); 
-		String f_num=dao.selectF_num(h_num, dto.getF_name());
+		FoodDto dto=list.get(i);
+		String f_num=dto.getF_num();
 
 		int pr=Integer.parseInt(dto.getF_price());
 		%>

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -19,7 +19,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Grandiflora+One&family=Gugi&family=Hahmlet:wght@100..900&family=Hi+Melody&family=Sunflower:wght@300&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>푸드코트 메뉴</title>
 <style type="text/css">
 #container {
   margin: 0 auto; 
@@ -236,8 +236,7 @@ HugesoInfoDto hdto=hdao.selectData(h_num);
 NumberFormat nf=NumberFormat.getInstance();
 %>
 <div class="img-container" style="border: 0px solid green; background-image: url('image/mainbanner/foodbanner01.png'); background-size: cover; background-position: center center;">
-		<%-- <img alt="" src="image/mainbanner/memberbanner01.jpg">--%>
-</div>
+	</div>
 <div class="span-container" style="border:0px solid purple; font-size: 2.5em;" >
 	<span> <%=util.SecurityUtil.escapeHtml(hdto.getH_name()) %>의 주문가능 메뉴<br>
 	<span style="display: block;font-size: 10pt;">*상기이미지는 실제메뉴와 차이가 있을 수 있습니다.*</span>

--- a/src/main/webapp/foodcourt/import.jsp
+++ b/src/main/webapp/foodcourt/import.jsp
@@ -1,10 +1,3 @@
-<%@page import="javax.swing.plaf.basic.BasicTextAreaUI"%>
-<%@page import="java.util.HashMap"%>
-<%@page import="java.util.List"%>
-<%@page import="meminfo.model.MemInfoDto"%>
-<%@page import="meminfo.model.MemInfoDao"%>
-<%@page import="foodcart.FoodCartDto"%>
-<%@page import="foodcart.FoodCartDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <!DOCTYPE html>
@@ -15,7 +8,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Grandiflora+One&family=Gugi&family=Hahmlet:wght@100..900&family=Hi+Melody&family=Sunflower:wght@300&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>결제</title>
 </head>
 <body>
 <%


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상) 리팩터링 — **푸드코트 장바구니(foodcart, foodcourt)** 도메인.
앞선 회원/휴게소/평점/음식·브랜드와 동일 규칙·강도(full rigor)로 진행. **동작 보존 원칙**(순수 리팩터링)이며, 아래 N+1 제거만 사용자 승인하에 의도된 효율/정확도 개선이다.

## 커밋 단위
1. **FoodCartDao 위생** — `db` 필드 private화, `// TODO Auto-generated catch block` 7개 제거(printStackTrace→로거 전환은 2단계 제외)
2. **죽은 코드 제거** — `getIdx(f_num,m_num)` 삭제(전 코드베이스 호출처 0건)
3. **조회 메서드 get*→select* 통일 + 호출처 갱신**
   - `getCartMenu`→`selectCartMenu` (foodcartlist.jsp, foodmenu.jsp)
   - `getCartCnt`→`selectCartItemExists` (boolean 존재확인 의미 반영, foodcartaddaction.jsp)
   - DTO 0-인자 게터(`getF_num` 등)는 미변경
4. **foodcourt JSP 위생** — foodmenu 죽은 `<img>` 줄 제거, import.jsp 본문 미사용 import 전부 제거, `<title>` 잔재 교체(foodmenu·foodcartaddaction·import)
5. **(교차도메인) foodmenu N+1 제거** — `selectFood(h_num)`가 채운 dto.f_num을 행마다 `selectF_num(h_num, f_name)`으로 재조회하던 것을 `dto.getF_num()`로 교체(행당 쿼리 제거 + 중복 음식명 시 부정확 교정). 고아가 된 `FoodDao.selectF_num(String,String)` 동반 제거
6. **(전역 컨벤션) 패키지 이동** — `foodcart`→`foodcart/model/`. FoodCartDao/Dto git mv(히스토리 보존) + package 선언 갱신, 참조 JSP 5개 import를 `foodcart.model.*`로 갱신

## 검증
- 각 커밋 **javac EXIT=0** (servlet-api 4.0.1 + WEB-INF/lib jar, -encoding UTF-8, src/main/java 전체)
- 도메인 diff에 **/simplify + /code-review(high)** 실행 → **버그 0건**
- import/호출처 정합 grep 전수 확인(`getCart*`·`selectF_num`·`foodcart.FoodCart` 잔재 0건)

## ⚠ Tomcat 스모크 테스트 필요
이 환경은 **Tomcat 런타임 검증이 불가**하다. 특히 **패키지 이동(커밋 6)**과 **N+1 교차도메인 변경(커밋 5)**은 javac 컴파일·grep 정합만 확인했으므로, 병합 전 다음 화면의 런타임 동작을 한 번 확인 권장:
- 푸드코트 메뉴(foodmenu) 진입 → 메뉴 목록·카트 조회 정상
- 장바구니 담기/개별삭제/전체삭제(foodcartaddaction/foodcartdelete/cartalldelete) 정상
- 결제 화면(import.jsp) 정상 로드

## 보안 보존
장바구니 액션의 로그인 가드·isPost·CSRF·세션 m_num 소유권(IDOR 방지) 및 escapeHtml/ImageServlet 경유 출력 인코딩은 모두 유지(미변경 라인). 약화 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
