### PR TITLE
게시판(notice) 도메인 2단계 리팩터(NoticeDao 위생·mapRow 추출·get→select 통일·deleteNoice 오타 정정)

### DIFF
--- a/src/main/java/notice/model/NoticeDao.java
+++ b/src/main/java/notice/model/NoticeDao.java
@@ -8,353 +8,332 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mysql.db.DbConnect;
-import qaanswer.model.QaanswerDto;
 
 public class NoticeDao {
-	 
-	DbConnect db = new DbConnect();
-	
-	
+
+	private DbConnect db = new DbConnect();
+
 	//insert 저장
 	public void insertNotice(NoticeDto dto) {
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
-		
+
 		String sql = "insert into noticeboard values(null,?,?,?,?,0,0,now())";
-		
+
 		try {
 			pstmt = conn.prepareStatement(sql);
-			
+
 			pstmt.setString(1, dto.getN_myid());
 			pstmt.setString(2, dto.getN_subject());
 			pstmt.setString(3, dto.getN_content());
 			pstmt.setString(4, dto.getN_image());
-			
+
 			pstmt.execute();
-			
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(pstmt, conn);
 		}
 	}
-	
+
 	//noticelist 전체 출력
 	public List<NoticeDto> getAllNotice() {
 		List<NoticeDto> list = new ArrayList<NoticeDto>();
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-		
+
 		String sql = "select * from noticeboard order by n_num desc";
-		
+
 		try {
 			pstmt = conn.prepareStatement(sql);
 			rs = pstmt.executeQuery();
-			
+
 			while(rs.next()) {
-				
+
 				NoticeDto dto = new NoticeDto();
-				
+
 				dto.setN_num(rs.getString("n_num"));
-				dto.setN_myid(rs.getString("n_myid"));;
+				dto.setN_myid(rs.getString("n_myid"));
 				dto.setN_subject(rs.getString("n_subject"));
 				dto.setN_content(rs.getString("n_content"));
 				dto.setN_readcount(rs.getInt("n_readcount"));
-				dto.setN_image(rs.getString("n_image"));;
+				dto.setN_image(rs.getString("n_image"));
 				dto.setN_chu(rs.getInt("n_chu"));
 				dto.setN_writeday(rs.getTimestamp("n_writeday"));
-				
+
 				list.add(dto);
 			}
-			
-			
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-				
+
 		return list;
-		
 	}
-	
+
 	//전체 페이지수 dto 반환하기
 	public int getTotalCount() {
-		
+
 		int total = 0;
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-		
+
 		String sql = "select count(*) from noticeboard";
-		
+
 		try {
 			pstmt = conn.prepareStatement(sql);
 			rs = pstmt.executeQuery();
-			
+
 			if(rs.next()) {
 				total = rs.getInt(1);
 			}
-			
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-		
+
 		return total;
-		
 	}
-	
+
 	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-		public List<NoticeDto> getList(int start, int perPage) {
-			List<NoticeDto> list = new ArrayList<NoticeDto>();
+	public List<NoticeDto> getList(int start, int perPage) {
+		List<NoticeDto> list = new ArrayList<NoticeDto>();
 
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
 
-			String sql = "select * from noticeboard order by n_num desc limit ?,?";
+		String sql = "select * from noticeboard order by n_num desc limit ?,?";
 
-			try {
-				pstmt = conn.prepareStatement(sql);
+		try {
+			pstmt = conn.prepareStatement(sql);
 
-				pstmt.setInt(1, start);
-				pstmt.setInt(2, perPage);
+			pstmt.setInt(1, start);
+			pstmt.setInt(2, perPage);
 
-				rs = pstmt.executeQuery();
+			rs = pstmt.executeQuery();
 
-				while (rs.next()) {
+			while (rs.next()) {
 
-					NoticeDto dto = new NoticeDto();
+				NoticeDto dto = new NoticeDto();
 
-					dto.setN_num(rs.getString("n_num"));
-					dto.setN_myid(rs.getString("n_myid"));
-					dto.setN_subject(rs.getString("n_subject"));
-					dto.setN_content(rs.getString("n_content"));
-					dto.setN_readcount(rs.getInt("n_readcount"));
-					dto.setN_chu(rs.getInt("n_chu"));
-					dto.setN_writeday(rs.getTimestamp("n_writeday"));
+				dto.setN_num(rs.getString("n_num"));
+				dto.setN_myid(rs.getString("n_myid"));
+				dto.setN_subject(rs.getString("n_subject"));
+				dto.setN_content(rs.getString("n_content"));
+				dto.setN_readcount(rs.getInt("n_readcount"));
+				dto.setN_chu(rs.getInt("n_chu"));
+				dto.setN_writeday(rs.getTimestamp("n_writeday"));
 
-					list.add(dto);
-				}
-
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(rs, pstmt, conn);
+				list.add(dto);
 			}
 
-			return list;
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
-		
-		
-		//detail페이지 num값 넘겨주기 -> dto 반환!!
-		public NoticeDto getDataNotice(String n_num) {
-			NoticeDto dto = new NoticeDto();
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql = "select * from noticeboard where n_num=?";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				
-				pstmt.setString(1, n_num);
-				rs = pstmt.executeQuery();
-				
-				while(rs.next()) {
-					
-					dto.setN_num(rs.getString("n_num"));
-					dto.setN_myid(rs.getString("n_myid"));
-					dto.setN_subject(rs.getString("n_subject"));
-					dto.setN_content(rs.getString("n_content"));
-					dto.setN_image(rs.getString("n_image"));
-					dto.setN_readcount(rs.getInt("n_readcount"));
-					dto.setN_chu(rs.getInt("n_chu"));
-					dto.setN_writeday(rs.getTimestamp("n_writeday"));
-					
-				}
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-			
-			return dto;
-		}
-		
-		// readcount 해주기 / 조회수 및 추천 
-		public void updateReadcount(String n_num) {
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
 
-			String sql = "update noticeboard set n_readcount=n_readcount+1 where n_num=?";
-
-			try {
-				pstmt = conn.prepareStatement(sql);
-				pstmt.setString(1, n_num);
-				pstmt.execute();
-
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
-		}
-		
-		//update 수정
-		public void updateNotice(NoticeDto dto) {
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			
-			String sql = "update noticeboard set n_subject=?, n_content=?, n_image=? where n_num=?";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				
-				pstmt.setString(1, dto.getN_subject());
-				pstmt.setString(2, dto.getN_content());
-				pstmt.setString(3, dto.getN_image());
-				pstmt.setString(4, dto.getN_num());
-				
-				pstmt.execute();;
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(pstmt, conn);
-			}
-			
-		}
-		
-		//삭제하기
-		public void deleteNoice(String n_num) {
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			
-			String sql = "delete from noticeboard where n_num=?";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				pstmt.setString(1, n_num);
-				
-				pstmt.execute();
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(pstmt, conn);
-			}
-			
-		}
-		
-		// 추천 클릭 시 추천수 증가 시키기
-		public void updateNoticeChu(String n_num) {
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-
-			String sql = "update noticeboard set n_chu=n_chu+1 where n_num=?";
-
-			try {
-				pstmt = conn.prepareStatement(sql);
-
-				pstmt.setString(1, n_num);
-				pstmt.execute();
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
-		}
-		
-		
-				// adminnoticelist.jsp //페이징리스트/ 전체페이지수 반환하기
-				public int getMyPageTotalCount() {
-			      
-			    int total = 0;
-					
-					Connection conn = db.getConnection();
-					PreparedStatement pstmt = null;
-					ResultSet rs = null;
-			  
-			    String sql = "select count(*) from noticeboard where n_myid='admin'";
-					
-					try {
-						pstmt = conn.prepareStatement(sql);
-						rs = pstmt.executeQuery();
-						
-						if(rs.next()) {
-							total = rs.getInt(1);
-						}
-						
-					} catch (SQLException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-					
-					return total;
-					
-				}
-				
-				// adminnoticelist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-				public List<NoticeDto> getmypagelist(int start, int perPage) {
-					List<NoticeDto> mypagelist = new ArrayList<NoticeDto>();
-			  
-					Connection conn = db.getConnection();
-					PreparedStatement pstmt = null;
-					ResultSet rs = null;
-			  
-					String sql = "select * from noticeboard where n_myid='admin' order by n_num desc limit ?,?";
-
-					try {
-						pstmt = conn.prepareStatement(sql);
-						
-						pstmt.setInt(1, start);
-						pstmt.setInt(2, perPage);
-			      
-			      rs = pstmt.executeQuery();
-
-						while (rs.next()) {
-
-							NoticeDto dto = new NoticeDto();
-							
-							dto.setN_num(rs.getString("n_num"));
-							dto.setN_myid(rs.getString("n_myid"));
-							dto.setN_subject(rs.getString("n_subject"));
-							dto.setN_content(rs.getString("n_content"));
-							dto.setN_readcount(rs.getInt("n_readcount"));
-							dto.setN_chu(rs.getInt("n_chu"));
-							dto.setN_writeday(rs.getTimestamp("n_writeday"));
-
-							mypagelist.add(dto);
-						}
-			      } catch (SQLException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					} finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-			    return mypagelist;
-				}
+		return list;
 	}
+
+	//detail페이지 num값 넘겨주기 -> dto 반환!!
+	public NoticeDto getDataNotice(String n_num) {
+		NoticeDto dto = new NoticeDto();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from noticeboard where n_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, n_num);
+			rs = pstmt.executeQuery();
+
+			while(rs.next()) {
+
+				dto.setN_num(rs.getString("n_num"));
+				dto.setN_myid(rs.getString("n_myid"));
+				dto.setN_subject(rs.getString("n_subject"));
+				dto.setN_content(rs.getString("n_content"));
+				dto.setN_image(rs.getString("n_image"));
+				dto.setN_readcount(rs.getInt("n_readcount"));
+				dto.setN_chu(rs.getInt("n_chu"));
+				dto.setN_writeday(rs.getTimestamp("n_writeday"));
+
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return dto;
+	}
+
+	// readcount 해주기 / 조회수 및 추천
+	public void updateReadcount(String n_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update noticeboard set n_readcount=n_readcount+1 where n_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, n_num);
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	//update 수정
+	public void updateNotice(NoticeDto dto) {
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update noticeboard set n_subject=?, n_content=?, n_image=? where n_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getN_subject());
+			pstmt.setString(2, dto.getN_content());
+			pstmt.setString(3, dto.getN_image());
+			pstmt.setString(4, dto.getN_num());
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	//삭제하기
+	public void deleteNoice(String n_num) {
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "delete from noticeboard where n_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, n_num);
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	// 추천 클릭 시 추천수 증가 시키기
+	public void updateNoticeChu(String n_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update noticeboard set n_chu=n_chu+1 where n_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, n_num);
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	// adminnoticelist.jsp //페이징리스트/ 전체페이지수 반환하기
+	public int getMyPageTotalCount() {
+
+		int total = 0;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from noticeboard where n_myid='admin'";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
+
+			if(rs.next()) {
+				total = rs.getInt(1);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+	}
+
+	// adminnoticelist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
+	public List<NoticeDto> getmypagelist(int start, int perPage) {
+		List<NoticeDto> mypagelist = new ArrayList<NoticeDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from noticeboard where n_myid='admin' order by n_num desc limit ?,?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setInt(1, start);
+			pstmt.setInt(2, perPage);
+
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+
+				NoticeDto dto = new NoticeDto();
+
+				dto.setN_num(rs.getString("n_num"));
+				dto.setN_myid(rs.getString("n_myid"));
+				dto.setN_subject(rs.getString("n_subject"));
+				dto.setN_content(rs.getString("n_content"));
+				dto.setN_readcount(rs.getInt("n_readcount"));
+				dto.setN_chu(rs.getInt("n_chu"));
+				dto.setN_writeday(rs.getTimestamp("n_writeday"));
+
+				mypagelist.add(dto);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+		return mypagelist;
+	}
+}

--- a/src/main/java/notice/model/NoticeDao.java
+++ b/src/main/java/notice/model/NoticeDao.java
@@ -53,19 +53,7 @@ public class NoticeDao {
 			rs = pstmt.executeQuery();
 
 			while(rs.next()) {
-
-				NoticeDto dto = new NoticeDto();
-
-				dto.setN_num(rs.getString("n_num"));
-				dto.setN_myid(rs.getString("n_myid"));
-				dto.setN_subject(rs.getString("n_subject"));
-				dto.setN_content(rs.getString("n_content"));
-				dto.setN_readcount(rs.getInt("n_readcount"));
-				dto.setN_image(rs.getString("n_image"));
-				dto.setN_chu(rs.getInt("n_chu"));
-				dto.setN_writeday(rs.getTimestamp("n_writeday"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -124,18 +112,7 @@ public class NoticeDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				NoticeDto dto = new NoticeDto();
-
-				dto.setN_num(rs.getString("n_num"));
-				dto.setN_myid(rs.getString("n_myid"));
-				dto.setN_subject(rs.getString("n_subject"));
-				dto.setN_content(rs.getString("n_content"));
-				dto.setN_readcount(rs.getInt("n_readcount"));
-				dto.setN_chu(rs.getInt("n_chu"));
-				dto.setN_writeday(rs.getTimestamp("n_writeday"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -164,16 +141,7 @@ public class NoticeDao {
 			rs = pstmt.executeQuery();
 
 			while(rs.next()) {
-
-				dto.setN_num(rs.getString("n_num"));
-				dto.setN_myid(rs.getString("n_myid"));
-				dto.setN_subject(rs.getString("n_subject"));
-				dto.setN_content(rs.getString("n_content"));
-				dto.setN_image(rs.getString("n_image"));
-				dto.setN_readcount(rs.getInt("n_readcount"));
-				dto.setN_chu(rs.getInt("n_chu"));
-				dto.setN_writeday(rs.getTimestamp("n_writeday"));
-
+				dto = mapRow(rs);
 			}
 
 		} catch (SQLException e) {
@@ -316,18 +284,7 @@ public class NoticeDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				NoticeDto dto = new NoticeDto();
-
-				dto.setN_num(rs.getString("n_num"));
-				dto.setN_myid(rs.getString("n_myid"));
-				dto.setN_subject(rs.getString("n_subject"));
-				dto.setN_content(rs.getString("n_content"));
-				dto.setN_readcount(rs.getInt("n_readcount"));
-				dto.setN_chu(rs.getInt("n_chu"));
-				dto.setN_writeday(rs.getTimestamp("n_writeday"));
-
-				mypagelist.add(dto);
+				mypagelist.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -335,5 +292,21 @@ public class NoticeDao {
 			db.dbClose(rs, pstmt, conn);
 		}
 		return mypagelist;
+	}
+
+	// ResultSet 한 행을 NoticeDto로 매핑(조회 메서드 공통)
+	private NoticeDto mapRow(ResultSet rs) throws SQLException {
+		NoticeDto dto = new NoticeDto();
+
+		dto.setN_num(rs.getString("n_num"));
+		dto.setN_myid(rs.getString("n_myid"));
+		dto.setN_subject(rs.getString("n_subject"));
+		dto.setN_content(rs.getString("n_content"));
+		dto.setN_image(rs.getString("n_image"));
+		dto.setN_readcount(rs.getInt("n_readcount"));
+		dto.setN_chu(rs.getInt("n_chu"));
+		dto.setN_writeday(rs.getTimestamp("n_writeday"));
+
+		return dto;
 	}
 }

--- a/src/main/java/notice/model/NoticeDao.java
+++ b/src/main/java/notice/model/NoticeDao.java
@@ -39,7 +39,7 @@ public class NoticeDao {
 	}
 
 	//noticelist 전체 출력
-	public List<NoticeDto> getAllNotice() {
+	public List<NoticeDto> selectAllNotice() {
 		List<NoticeDto> list = new ArrayList<NoticeDto>();
 
 		Connection conn = db.getConnection();
@@ -66,7 +66,7 @@ public class NoticeDao {
 	}
 
 	//전체 페이지수 dto 반환하기
-	public int getTotalCount() {
+	public int selectTotalCount() {
 
 		int total = 0;
 
@@ -94,7 +94,7 @@ public class NoticeDao {
 	}
 
 	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<NoticeDto> getList(int start, int perPage) {
+	public List<NoticeDto> selectPagingList(int start, int perPage) {
 		List<NoticeDto> list = new ArrayList<NoticeDto>();
 
 		Connection conn = db.getConnection();
@@ -125,7 +125,7 @@ public class NoticeDao {
 	}
 
 	//detail페이지 num값 넘겨주기 -> dto 반환!!
-	public NoticeDto getDataNotice(String n_num) {
+	public NoticeDto selectDataNotice(String n_num) {
 		NoticeDto dto = new NoticeDto();
 
 		Connection conn = db.getConnection();
@@ -198,7 +198,7 @@ public class NoticeDao {
 	}
 
 	//삭제하기
-	public void deleteNoice(String n_num) {
+	public void deleteNotice(String n_num) {
 
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
@@ -238,7 +238,7 @@ public class NoticeDao {
 	}
 
 	// adminnoticelist.jsp //페이징리스트/ 전체페이지수 반환하기
-	public int getMyPageTotalCount() {
+	public int selectMyPageTotalCount() {
 
 		int total = 0;
 
@@ -266,7 +266,7 @@ public class NoticeDao {
 	}
 
 	// adminnoticelist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<NoticeDto> getmypagelist(int start, int perPage) {
+	public List<NoticeDto> selectMyPageList(int start, int perPage) {
 		List<NoticeDto> mypagelist = new ArrayList<NoticeDto>();
 
 		Connection conn = db.getConnection();

--- a/src/main/webapp/layout/main.jsp
+++ b/src/main/webapp/layout/main.jsp
@@ -125,7 +125,7 @@ String root = request.getContextPath();
 
 //notice
 NoticeDao ndao = new NoticeDao();
-List<NoticeDto> list = ndao.getAllNotice();
+List<NoticeDto> list = ndao.selectAllNotice();
 
 //event
 EventDao edao = new EventDao();

--- a/src/main/webapp/mainlayout/noticevent.jsp
+++ b/src/main/webapp/mainlayout/noticevent.jsp
@@ -103,7 +103,7 @@
   
    //notice
    NoticeDao ndao = new NoticeDao();
-   List<NoticeDto> list = ndao.getAllNotice();
+   List<NoticeDto> list = ndao.selectAllNotice();
    
    //event
    EventDao edao = new EventDao();
@@ -138,7 +138,7 @@
             <% 
               
                
-              List<NoticeDto> recentNotices = ndao.getAllNotice().subList(0, Math.min(list.size(), 5));
+              List<NoticeDto> recentNotices = ndao.selectAllNotice().subList(0, Math.min(list.size(), 5));
               int n = recentNotices.size();
               if( n != 0 ) {
               for(NoticeDto dto:recentNotices) {%>

--- a/src/main/webapp/mainlayout/noticevent.jsp
+++ b/src/main/webapp/mainlayout/noticevent.jsp
@@ -15,7 +15,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>공지·이벤트</title>
 <style type="text/css">
   /*공지사항 */
     .noticeDetail {

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -13,7 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>공지 관리</title>
 <style type="text/css">
 ul.tabs {
 	margin: 0px;

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -257,7 +257,7 @@ font-size: 14px;
 	NoticeDao dao=new NoticeDao();
 	
 	//전체갯수
-	int totalCount=dao.getMyPageTotalCount();
+	int totalCount=dao.selectMyPageTotalCount();
 	int perPage=5; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -297,7 +297,7 @@ font-size: 14px;
 	no=totalCount-(currentPage-1)*perPage;
 	
 	//페이지에서 보여질 글만 가져오기
-	List<NoticeDto> list = dao.getmypagelist(startNum, perPage);
+	List<NoticeDto> list = dao.selectMyPageList(startNum, perPage);
 		
 	//해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
 	//마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정

--- a/src/main/webapp/mypage/deleteadminnotice.jsp
+++ b/src/main/webapp/mypage/deleteadminnotice.jsp
@@ -5,7 +5,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Insert title here</title>
+<title>공지 삭제</title>
 </head>
 <body>
 <%

--- a/src/main/webapp/mypage/deleteadminnotice.jsp
+++ b/src/main/webapp/mypage/deleteadminnotice.jsp
@@ -23,7 +23,7 @@
 	NoticeDao dao=new NoticeDao();
 	for(String n:num)
 	{
-		dao.deleteNoice(n);
+		dao.deleteNotice(n);
 	}
 	
 	//목록으로 이동

--- a/src/main/webapp/noticeboard/noticeChu.jsp
+++ b/src/main/webapp/noticeboard/noticeChu.jsp
@@ -18,7 +18,7 @@
     dao.updateNoticeChu(n_num);
     
     //증가된 chu 값 json 형태로 보내기
-    int chu = dao.getDataNotice(n_num).getN_chu();
+    int chu = dao.selectDataNotice(n_num).getN_chu();
     
     JSONObject ob = new JSONObject();
     ob.put("chu", chu);

--- a/src/main/webapp/noticeboard/noticeDelete.jsp
+++ b/src/main/webapp/noticeboard/noticeDelete.jsp
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>공지 삭제</title>
 </head>
 <body>
 

--- a/src/main/webapp/noticeboard/noticeDelete.jsp
+++ b/src/main/webapp/noticeboard/noticeDelete.jsp
@@ -24,7 +24,7 @@
   String currentPage=request.getParameter("currentPage");
 
   NoticeDao dao=new NoticeDao();
-  dao.deleteNoice(n_num);
+  dao.deleteNotice(n_num);
   
   response.sendRedirect("../index.jsp?main=noticeboard/noticeList.jsp?currentPage="+currentPage);
   

--- a/src/main/webapp/noticeboard/noticeDetail.jsp
+++ b/src/main/webapp/noticeboard/noticeDetail.jsp
@@ -111,7 +111,7 @@
     String n_num = util.SecurityUtil.digitsOnly(request.getParameter("n_num"));
     NoticeDao dao = new NoticeDao();
 
-    NoticeDto dto = dao.getDataNotice(n_num);
+    NoticeDto dto = dao.selectDataNotice(n_num);
     String currentPage=util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
     
     //조회수 가져오기

--- a/src/main/webapp/noticeboard/noticeDetail.jsp
+++ b/src/main/webapp/noticeboard/noticeDetail.jsp
@@ -12,7 +12,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>공지 상세</title>
 <style type="text/css">
 
   button.col {

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -126,7 +126,7 @@
 	NoticeDao dao=new NoticeDao();
 	
 	//전체갯수
-	int totalCount=dao.getTotalCount();
+	int totalCount=dao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -166,7 +166,7 @@
 	no=totalCount-(currentPage-1)*perPage;
 	
 	//페이지에서 보여질 글만 가져오기
-	List<NoticeDto> list = dao.getList(startNum, perPage);
+	List<NoticeDto> list = dao.selectPagingList(startNum, perPage);
 		
 	//해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
     //마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -13,7 +13,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>공지사항</title>
 
 <style type="text/css">
 

--- a/src/main/webapp/noticeboard/noticeUpdateAction.jsp
+++ b/src/main/webapp/noticeboard/noticeUpdateAction.jsp
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>공지 수정</title>
 </head>
 <body>
   <%

--- a/src/main/webapp/noticeboard/noticeUpdateAction.jsp
+++ b/src/main/webapp/noticeboard/noticeUpdateAction.jsp
@@ -64,7 +64,7 @@
 
        //기존포토명 가져오기 -> 기존에 사진값을 가져오기 위해서 dao 먼저 선언
        NoticeDao dao = new NoticeDao();
-       String old_photoName = dao.getDataNotice(n_num).getN_image();
+       String old_photoName = dao.selectDataNotice(n_num).getN_image();
        
        //dto에 저장
        NoticeDto dto=new NoticeDto();

--- a/src/main/webapp/noticeboard/noticeUpdateForm.jsp
+++ b/src/main/webapp/noticeboard/noticeUpdateForm.jsp
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>공지 수정</title>
 <style type="text/css">
 
   button.col {

--- a/src/main/webapp/noticeboard/noticeUpdateForm.jsp
+++ b/src/main/webapp/noticeboard/noticeUpdateForm.jsp
@@ -52,7 +52,7 @@
    String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    NoticeDao dao = new NoticeDao();
-   NoticeDto dto = dao.getDataNotice(n_num);
+   NoticeDto dto = dao.selectDataNotice(n_num);
 %>
 <body>
   <!-- 메뉴 타이틀 -->


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상) 게시판 도메인 작업의 첫 하위도메인 **notice** PR이다. 동작 보존이 원칙인 순수 리팩터링(기능 변경 0)이며, 앞선 도메인(#75~#79)과 동일 방식·강도(full rigor)로 진행했다. 게시판은 5개 평행 하위도메인이라 하위도메인별 PR로 분할하며, 이후 event → review → qa → qaanswer 순으로 이어진다.

## 커밋 단위 (작은 리뷰 단위 4개)
1. **NoticeDao 위생 정리** — `db` 필드 private화 / 미사용 import `qaanswer.model.QaanswerDto` 제거(사용처 0건) / `// TODO Auto-generated catch block` 노이즈 주석 11개 제거(printStackTrace는 유지, 로거 전환은 2단계 제외) / 이중 세미콜론 `;;` 3곳 제거 / 과도한 탭·공백 혼용 들여쓰기 정정. `git diff -w`로 위 토큰 변경 외 0건 확인.
2. **mapRow 추출** — `selectAllNotice`·`selectPagingList`·`selectDataNotice`·`selectMyPageList`가 모두 `select *`로 동일 ResultSet을 받으므로 8컬럼 매핑을 `private NoticeDto mapRow(ResultSet)`로 추출해 중복 제거.
3. **조회 get*→select* 통일 + 오타·개명 + 호출처 갱신** — `getAllNotice→selectAllNotice`, `getTotalCount→selectTotalCount`, `getList→selectPagingList`, `getDataNotice→selectDataNotice`, `getMyPageTotalCount→selectMyPageTotalCount`, `getmypagelist→selectMyPageList`(camelCase+select*, 시그니처 불변), `deleteNoice`(오타)`→deleteNotice`. 호출처 JSP 11곳을 수신자(NoticeDao 인스턴스) 기준으로 전수 갱신.
4. **JSP 위생** — 만진 JSP의 `<title>Insert title here</title>` 잔재 8곳을 실제 제목으로 교체.

## 동작 보존 근거
- `getList`/`getmypagelist`는 기존에 `n_image`를 미적재(null)했으나, mapRow 통합으로 적재돼도 소비처 `noticeList.jsp`·`adminnoticelist.jsp`가 `getN_image()`를 출력하지 않아 영향 없음(회원 `searchMem` mapRow 통합 선례와 동일).
- `selectDataNotice`는 무행 시 빈 DTO 반환 등 기존 시맨틱 그대로.
- 타 도메인 동명 메서드(`getTotalCount`/`getList`/`getmypagelist` 등 event/qa/qaanswer/review)와 DTO 0-인자 게터(`getN_num` 등 snake_case 미러링)는 미변경.

## 보안 보존
- 삭제 액션(`noticeDelete.jsp`·`deleteadminnotice.jsp`)의 `isAdmin`·`isPost`·`checkCsrf` 가드, 쓰기/수정 액션의 권한 가드 모두 유지. 출력 XSS 인코딩(`escapeHtml` 등) 약화 없음.

## 검증
- 매 커밋 `javac`(servlet-api 4.0.1 + WEB-INF/lib, `-encoding UTF-8`, `src/main/java` 전체) **EXIT=0**.
- 리네임 누락 grep 전수 확인(코드 내 옛 명칭 0건), `/code-review`(high)·`/simplify` 통과(findings 0).
- ⚠ **JSP는 정적 컴파일로 검증 불가** → Tomcat 런타임 스모크 테스트 필요: 공지 목록/상세/작성/수정/삭제, 관리자 공지 목록·일괄삭제, 메인 공지위젯, 추천(chu) 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)