### PR TITLE
게시판이벤트(event) 2단계 코드 컨벤션 정리

### DIFF
--- a/src/main/java/event/model/EventDao.java
+++ b/src/main/java/event/model/EventDao.java
@@ -39,7 +39,7 @@ public class EventDao {
 	}
 
 	//noticelist 전체 출력
-	public List<EventDto> getAllEvent() {
+	public List<EventDto> selectAllEvent() {
 		List<EventDto> list = new ArrayList<EventDto>();
 
 		Connection conn = db.getConnection();
@@ -67,7 +67,7 @@ public class EventDao {
 	}
 
 	//전체 페이지수 dto 반환하기
-	public int getTotalCount() {
+	public int selectTotalCount() {
 
 		int total = 0;
 
@@ -96,7 +96,7 @@ public class EventDao {
 	}
 
 	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<EventDto> getList(int start, int perPage) {
+	public List<EventDto> selectPagingList(int start, int perPage) {
 		List<EventDto> list = new ArrayList<EventDto>();
 
 		Connection conn = db.getConnection();
@@ -127,7 +127,7 @@ public class EventDao {
 	}
 
 	//detail페이지 num값 넘겨주기 -> dto 반환!!
-	public EventDto getDataEvent(String e_num) {
+	public EventDto selectDataEvent(String e_num) {
 		EventDto dto = new EventDto();
 
 		Connection conn = db.getConnection();
@@ -242,7 +242,7 @@ public class EventDao {
 	}
 
 	// admineventlist.jsp //페이징리스트/ 전체페이지수 반환하기
-	public int getMyPageTotalCount() {
+	public int selectMyPageTotalCount() {
 
 		int total = 0;
 
@@ -271,7 +271,7 @@ public class EventDao {
 	}
 
 	// admineventlist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<EventDto> getmypagelist(int start, int perPage) {
+	public List<EventDto> selectMyPageList(int start, int perPage) {
 		List<EventDto> mypagelist = new ArrayList<EventDto>();
 
 		Connection conn = db.getConnection();

--- a/src/main/java/event/model/EventDao.java
+++ b/src/main/java/event/model/EventDao.java
@@ -53,18 +53,7 @@ public class EventDao {
 			rs = pstmt.executeQuery();
 
 			while(rs.next()) {
-
-				EventDto dto = new EventDto();
-
-				dto.setE_num(rs.getString("e_num"));
-				dto.setE_myid(rs.getString("e_myid"));
-				dto.setE_subject(rs.getString("e_subject"));
-				dto.setE_content(rs.getString("e_content"));
-				dto.setE_readcount(rs.getInt("e_readcount"));
-				dto.setE_chu(rs.getInt("e_chu"));
-				dto.setE_writeday(rs.getTimestamp("e_writeday"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -125,18 +114,7 @@ public class EventDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				EventDto dto = new EventDto();
-
-				dto.setE_num(rs.getString("e_num"));
-				dto.setE_myid(rs.getString("e_myid"));
-				dto.setE_subject(rs.getString("e_subject"));
-				dto.setE_content(rs.getString("e_content"));
-				dto.setE_readcount(rs.getInt("e_readcount"));
-				dto.setE_chu(rs.getInt("e_chu"));
-				dto.setE_writeday(rs.getTimestamp("e_writeday"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -165,16 +143,7 @@ public class EventDao {
 			rs = pstmt.executeQuery();
 
 			while(rs.next()) {
-
-				dto.setE_num(rs.getString("e_num"));
-				dto.setE_myid(rs.getString("e_myid"));
-				dto.setE_subject(rs.getString("e_subject"));
-				dto.setE_content(rs.getString("e_content"));
-				dto.setE_image(rs.getString("e_image"));
-				dto.setE_readcount(rs.getInt("e_readcount"));
-				dto.setE_chu(rs.getInt("e_chu"));
-				dto.setE_writeday(rs.getTimestamp("e_writeday"));
-
+				dto = mapRow(rs);
 			}
 
 		} catch (SQLException e) {
@@ -320,18 +289,7 @@ public class EventDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				EventDto dto = new EventDto();
-
-				dto.setE_num(rs.getString("e_num"));
-				dto.setE_myid(rs.getString("e_myid"));
-				dto.setE_subject(rs.getString("e_subject"));
-				dto.setE_content(rs.getString("e_content"));
-				dto.setE_readcount(rs.getInt("e_readcount"));
-				dto.setE_chu(rs.getInt("e_chu"));
-				dto.setE_writeday(rs.getTimestamp("e_writeday"));
-
-				mypagelist.add(dto);
+				mypagelist.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -339,6 +297,22 @@ public class EventDao {
 			db.dbClose(rs, pstmt, conn);
 		}
 		return mypagelist;
+	}
+
+	// ResultSet 한 행을 EventDto로 매핑(조회 메서드 공통)
+	private EventDto mapRow(ResultSet rs) throws SQLException {
+		EventDto dto = new EventDto();
+
+		dto.setE_num(rs.getString("e_num"));
+		dto.setE_myid(rs.getString("e_myid"));
+		dto.setE_subject(rs.getString("e_subject"));
+		dto.setE_content(rs.getString("e_content"));
+		dto.setE_image(rs.getString("e_image"));
+		dto.setE_readcount(rs.getInt("e_readcount"));
+		dto.setE_chu(rs.getInt("e_chu"));
+		dto.setE_writeday(rs.getTimestamp("e_writeday"));
+
+		return dto;
 	}
 
 }

--- a/src/main/java/event/model/EventDao.java
+++ b/src/main/java/event/model/EventDao.java
@@ -8,353 +8,337 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mysql.db.DbConnect;
-import notice.model.NoticeDto;
 
 public class EventDao {
-	
-	DbConnect db = new DbConnect();
-	
+
+	private DbConnect db = new DbConnect();
+
 	//insert 저장
-		public void insertEvent(EventDto dto) {
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			
-			String sql = "insert into eventboard values(null,?,?,?,?,0,0,now())";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				
-				pstmt.setString(1, dto.getE_myid());
-				pstmt.setString(2, dto.getE_subject());
-				pstmt.setString(3, dto.getE_content());
-				pstmt.setString(4, dto.getE_image());
-				
-				pstmt.execute();
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(pstmt, conn);
-			}
+	public void insertEvent(EventDto dto) {
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "insert into eventboard values(null,?,?,?,?,0,0,now())";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getE_myid());
+			pstmt.setString(2, dto.getE_subject());
+			pstmt.setString(3, dto.getE_content());
+			pstmt.setString(4, dto.getE_image());
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
 		}
-		
-		
-		
-		//noticelist 전체 출력
-		public List<EventDto> getAllEvent() {
-			List<EventDto> list = new ArrayList<EventDto>();
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql = "select * from eventboard order by e_num desc";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				rs = pstmt.executeQuery();
-				
-				while(rs.next()) {
-					
-					EventDto dto = new EventDto();
-					
-					dto.setE_num(rs.getString("e_num"));
-					dto.setE_myid(rs.getString("e_myid"));
-					dto.setE_subject(rs.getString("e_subject"));
-					dto.setE_content(rs.getString("e_content"));
-					dto.setE_readcount(rs.getInt("e_readcount"));
-					dto.setE_chu(rs.getInt("e_chu"));
-					dto.setE_writeday(rs.getTimestamp("e_writeday"));
-					
-					list.add(dto);
-				}
-				
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-					
-			return list;
-			
-		}
-		
-		//전체 페이지수 dto 반환하기
-		public int getTotalCount() {
-			
-			int total = 0;
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql = "select count(*) from eventboard";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				rs = pstmt.executeQuery();
-				
-				if(rs.next()) {
-					total = rs.getInt(1);
-				}
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-			
-			return total;
-			
-		}
-		
-		// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-			public List<EventDto> getList(int start, int perPage) {
-				List<EventDto> list = new ArrayList<EventDto>();
+	}
 
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				ResultSet rs = null;
+	//noticelist 전체 출력
+	public List<EventDto> getAllEvent() {
+		List<EventDto> list = new ArrayList<EventDto>();
 
-				String sql = "select * from eventboard order by e_num desc limit ?,?";
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
 
-				try {
-					pstmt = conn.prepareStatement(sql);
+		String sql = "select * from eventboard order by e_num desc";
 
-					pstmt.setInt(1, start);
-					pstmt.setInt(2, perPage);
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
 
-					rs = pstmt.executeQuery();
+			while(rs.next()) {
 
-					while (rs.next()) {
-
-						EventDto dto = new EventDto();
-
-						dto.setE_num(rs.getString("e_num"));
-						dto.setE_myid(rs.getString("e_myid"));
-						dto.setE_subject(rs.getString("e_subject"));
-						dto.setE_content(rs.getString("e_content"));
-						dto.setE_readcount(rs.getInt("e_readcount"));
-						dto.setE_chu(rs.getInt("e_chu"));
-						dto.setE_writeday(rs.getTimestamp("e_writeday"));
-
-						list.add(dto);
-					}
-
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				} finally {
-					db.dbClose(rs, pstmt, conn);
-				}
-
-				return list;
-			}
-			
-			
-			//detail페이지 num값 넘겨주기 -> dto 반환!!
-			public EventDto getDataEvent(String e_num) {
 				EventDto dto = new EventDto();
-				
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				ResultSet rs = null;
-				
-				String sql = "select * from eventboard where e_num=?";
-				
-				try {
-					pstmt = conn.prepareStatement(sql);
-					
-					pstmt.setString(1, e_num);
-					rs = pstmt.executeQuery();
-					
-					while(rs.next()) {
-						
-						dto.setE_num(rs.getString("e_num"));
-						dto.setE_myid(rs.getString("e_myid"));
-						dto.setE_subject(rs.getString("e_subject"));
-						dto.setE_content(rs.getString("e_content"));
-						dto.setE_image(rs.getString("e_image"));
-						dto.setE_readcount(rs.getInt("e_readcount"));
-						dto.setE_chu(rs.getInt("e_chu"));
-						dto.setE_writeday(rs.getTimestamp("e_writeday"));
-						
-					}
-					
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}finally {
-					db.dbClose(rs, pstmt, conn);
-				}
-				
-				return dto;
+
+				dto.setE_num(rs.getString("e_num"));
+				dto.setE_myid(rs.getString("e_myid"));
+				dto.setE_subject(rs.getString("e_subject"));
+				dto.setE_content(rs.getString("e_content"));
+				dto.setE_readcount(rs.getInt("e_readcount"));
+				dto.setE_chu(rs.getInt("e_chu"));
+				dto.setE_writeday(rs.getTimestamp("e_writeday"));
+
+				list.add(dto);
 			}
-			
-			// readcount 해주기 / 조회수 및 추천 
-			public void updateReadcount(String e_num) {
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
 
-				String sql = "update eventboard set e_readcount=e_readcount+1 where e_num=?";
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
 
-				try {
-					pstmt = conn.prepareStatement(sql);
-					pstmt.setString(1, e_num);
-					pstmt.execute();
+		return list;
 
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				} finally {
-					db.dbClose(pstmt, conn);
-				}
+	}
+
+	//전체 페이지수 dto 반환하기
+	public int getTotalCount() {
+
+		int total = 0;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from eventboard";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
+
+			if(rs.next()) {
+				total = rs.getInt(1);
 			}
-			
-			//update 수정
-			public void updateEvent(EventDto dto) {
-				
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				
-				String sql = "update eventboard set e_subject=?, e_content=?, e_image=? where e_num=?";
-				
-				try {
-					pstmt = conn.prepareStatement(sql);
-					
-					pstmt.setString(1, dto.getE_subject());
-					pstmt.setString(2, dto.getE_content());
-					pstmt.setString(3, dto.getE_image());
-					pstmt.setString(4, dto.getE_num());
-					
-					pstmt.execute();;
-					
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}finally {
-					db.dbClose(pstmt, conn);
-				}
-				
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+
+	}
+
+	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
+	public List<EventDto> getList(int start, int perPage) {
+		List<EventDto> list = new ArrayList<EventDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from eventboard order by e_num desc limit ?,?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setInt(1, start);
+			pstmt.setInt(2, perPage);
+
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+
+				EventDto dto = new EventDto();
+
+				dto.setE_num(rs.getString("e_num"));
+				dto.setE_myid(rs.getString("e_myid"));
+				dto.setE_subject(rs.getString("e_subject"));
+				dto.setE_content(rs.getString("e_content"));
+				dto.setE_readcount(rs.getInt("e_readcount"));
+				dto.setE_chu(rs.getInt("e_chu"));
+				dto.setE_writeday(rs.getTimestamp("e_writeday"));
+
+				list.add(dto);
 			}
-			
-			//삭제하기
-			public void deleteEvent(String e_num) {
-				
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				
-				String sql = "delete from eventboard where e_num=?";
-				
-				try {
-					pstmt = conn.prepareStatement(sql);
-					pstmt.setString(1, e_num);
-					
-					pstmt.execute();
-					
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}finally {
-					db.dbClose(pstmt, conn);
-				}
-				
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return list;
+	}
+
+	//detail페이지 num값 넘겨주기 -> dto 반환!!
+	public EventDto getDataEvent(String e_num) {
+		EventDto dto = new EventDto();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from eventboard where e_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, e_num);
+			rs = pstmt.executeQuery();
+
+			while(rs.next()) {
+
+				dto.setE_num(rs.getString("e_num"));
+				dto.setE_myid(rs.getString("e_myid"));
+				dto.setE_subject(rs.getString("e_subject"));
+				dto.setE_content(rs.getString("e_content"));
+				dto.setE_image(rs.getString("e_image"));
+				dto.setE_readcount(rs.getInt("e_readcount"));
+				dto.setE_chu(rs.getInt("e_chu"));
+				dto.setE_writeday(rs.getTimestamp("e_writeday"));
+
 			}
-			
-			// 추천 클릭 시 추천수 증가 시키기
-			public void updateEventChu(String e_num) {
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
 
-				String sql = "update eventboard set e_chu=e_chu+1 where e_num=?";
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
 
-				try {
-					pstmt = conn.prepareStatement(sql);
+		return dto;
+	}
 
-					pstmt.setString(1, e_num);
-					pstmt.execute();
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				} finally {
-					db.dbClose(pstmt, conn);
-				}
+	// readcount 해주기 / 조회수 및 추천
+	public void updateReadcount(String e_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update eventboard set e_readcount=e_readcount+1 where e_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, e_num);
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	//update 수정
+	public void updateEvent(EventDto dto) {
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update eventboard set e_subject=?, e_content=?, e_image=? where e_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getE_subject());
+			pstmt.setString(2, dto.getE_content());
+			pstmt.setString(3, dto.getE_image());
+			pstmt.setString(4, dto.getE_num());
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+
+	}
+
+	//삭제하기
+	public void deleteEvent(String e_num) {
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "delete from eventboard where e_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, e_num);
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+
+	}
+
+	// 추천 클릭 시 추천수 증가 시키기
+	public void updateEventChu(String e_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update eventboard set e_chu=e_chu+1 where e_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, e_num);
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	// admineventlist.jsp //페이징리스트/ 전체페이지수 반환하기
+	public int getMyPageTotalCount() {
+
+		int total = 0;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from eventboard where e_myid='admin'";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
+
+			if(rs.next()) {
+				total = rs.getInt(1);
 			}
-			
-			// admineventlist.jsp //페이징리스트/ 전체페이지수 반환하기
-			public int getMyPageTotalCount() {
-		      
-		    int total = 0;
-				
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				ResultSet rs = null;
-		  
-		    String sql = "select count(*) from eventboard where e_myid='admin'";
-				
-				try {
-					pstmt = conn.prepareStatement(sql);
-					rs = pstmt.executeQuery();
-					
-					if(rs.next()) {
-						total = rs.getInt(1);
-					}
-					
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}finally {
-					db.dbClose(rs, pstmt, conn);
-				}
-				
-				return total;
-				
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+
+	}
+
+	// admineventlist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
+	public List<EventDto> getmypagelist(int start, int perPage) {
+		List<EventDto> mypagelist = new ArrayList<EventDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from eventboard where e_myid='admin' order by e_num desc limit ?,?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setInt(1, start);
+			pstmt.setInt(2, perPage);
+
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+
+				EventDto dto = new EventDto();
+
+				dto.setE_num(rs.getString("e_num"));
+				dto.setE_myid(rs.getString("e_myid"));
+				dto.setE_subject(rs.getString("e_subject"));
+				dto.setE_content(rs.getString("e_content"));
+				dto.setE_readcount(rs.getInt("e_readcount"));
+				dto.setE_chu(rs.getInt("e_chu"));
+				dto.setE_writeday(rs.getTimestamp("e_writeday"));
+
+				mypagelist.add(dto);
 			}
-			
-			// admineventlist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-			public List<EventDto> getmypagelist(int start, int perPage) {
-				List<EventDto> mypagelist = new ArrayList<EventDto>();
-		  
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				ResultSet rs = null;
-		  
-				String sql = "select * from eventboard where e_myid='admin' order by e_num desc limit ?,?";
-
-				try {
-					pstmt = conn.prepareStatement(sql);
-					
-					pstmt.setInt(1, start);
-					pstmt.setInt(2, perPage);
-		      
-		      rs = pstmt.executeQuery();
-
-					while (rs.next()) {
-
-						EventDto dto = new EventDto();
-				
-						dto.setE_num(rs.getString("e_num"));
-						dto.setE_myid(rs.getString("e_myid"));
-						dto.setE_subject(rs.getString("e_subject"));
-						dto.setE_content(rs.getString("e_content"));
-						dto.setE_readcount(rs.getInt("e_readcount"));
-						dto.setE_chu(rs.getInt("e_chu"));
-						dto.setE_writeday(rs.getTimestamp("e_writeday"));
-						
-						mypagelist.add(dto);
-					}
-		      } catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				} finally {
-					db.dbClose(rs, pstmt, conn);
-				}
-		    return mypagelist;
-			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+		return mypagelist;
+	}
 
 }

--- a/src/main/webapp/eventboard/eventChu.jsp
+++ b/src/main/webapp/eventboard/eventChu.jsp
@@ -16,7 +16,7 @@
   dao.updateEventChu(e_num);
 
   // 증가된 chu 값 json 형태로 보내기
-  int chu = dao.getDataEvent(e_num).getE_chu();
+  int chu = dao.selectDataEvent(e_num).getE_chu();
 
   JSONObject ob = new JSONObject();
   ob.put("chu", chu);

--- a/src/main/webapp/eventboard/eventDetail.jsp
+++ b/src/main/webapp/eventboard/eventDetail.jsp
@@ -12,7 +12,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>이벤트 상세</title>
 <style type="text/css">
 
   button.col {

--- a/src/main/webapp/eventboard/eventDetail.jsp
+++ b/src/main/webapp/eventboard/eventDetail.jsp
@@ -108,7 +108,7 @@
     String e_num = util.SecurityUtil.digitsOnly(request.getParameter("e_num"));
     EventDao dao = new EventDao();
 
-    EventDto dto = dao.getDataEvent(e_num);
+    EventDto dto = dao.selectDataEvent(e_num);
     String currentPage=util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
     
     //조회수 가져오기

--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>이벤트</title>
 
  <style type="text/css">
 

--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -126,7 +126,7 @@
 	EventDao dao=new EventDao();
 	
 	//전체갯수
-	int totalCount=dao.getTotalCount();
+	int totalCount=dao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -166,7 +166,7 @@
 	no=totalCount-(currentPage-1)*perPage;
 	
 	//페이지에서 보여질 글만 가져오기
-	List<EventDto> list = dao.getList(startNum, perPage);
+	List<EventDto> list = dao.selectPagingList(startNum, perPage);
 		
 	//날짜변경
 	SimpleDateFormat sdf=new SimpleDateFormat("yyyy-MM-dd");

--- a/src/main/webapp/eventboard/eventUpdateAction.jsp
+++ b/src/main/webapp/eventboard/eventUpdateAction.jsp
@@ -64,7 +64,7 @@
 
        //기존포토명 가져오기 -> 기존에 사진값을 가져오기 위해서 dao 먼저 선언
        EventDao dao = new EventDao();
-       String old_photoName = dao.getDataEvent(e_num).getE_image();
+       String old_photoName = dao.selectDataEvent(e_num).getE_image();
        
        //dto에 저장
        EventDto dto=new EventDto();

--- a/src/main/webapp/eventboard/eventUpdateAction.jsp
+++ b/src/main/webapp/eventboard/eventUpdateAction.jsp
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>이벤트 수정</title>
 </head>
 <body>
     <%

--- a/src/main/webapp/eventboard/eventUpdateForm.jsp
+++ b/src/main/webapp/eventboard/eventUpdateForm.jsp
@@ -52,7 +52,7 @@
    String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    EventDao dao = new EventDao();
-   EventDto dto = dao.getDataEvent(e_num);
+   EventDto dto = dao.selectDataEvent(e_num);
 %>
 <body>
   <!-- 메뉴 타이틀 -->

--- a/src/main/webapp/eventboard/eventUpdateForm.jsp
+++ b/src/main/webapp/eventboard/eventUpdateForm.jsp
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>이벤트 수정</title>
 <style type="text/css">
 
   button.col {

--- a/src/main/webapp/layout/main.jsp
+++ b/src/main/webapp/layout/main.jsp
@@ -129,7 +129,7 @@ List<NoticeDto> list = ndao.selectAllNotice();
 
 //event
 EventDao edao = new EventDao();
-List<EventDto> elist = edao.getAllEvent();
+List<EventDto> elist = edao.selectAllEvent();
 %>
 <body>
 <div id="total_main">

--- a/src/main/webapp/mainlayout/noticevent.jsp
+++ b/src/main/webapp/mainlayout/noticevent.jsp
@@ -107,7 +107,7 @@
    
    //event
    EventDao edao = new EventDao();
-   List<EventDto> elist = edao.getAllEvent();
+   List<EventDto> elist = edao.selectAllEvent();
    
    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -172,7 +172,7 @@
           <tr>
             <% 
 
-              List<EventDto> recentEvent = edao.getAllEvent().subList(0, Math.min(elist.size(), 3));
+              List<EventDto> recentEvent = edao.selectAllEvent().subList(0, Math.min(elist.size(), 3));
               int e = recentEvent.size();
               if( e != 0 ) {
               for(EventDto dto:recentEvent) {%>

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -13,7 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>이벤트 관리</title>
 <style type="text/css">
 ul.tabs {
 	margin: 0px;

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -257,7 +257,7 @@ font-size: 14px;
 	EventDao dao=new EventDao();
 	
 	//전체갯수
-	int totalCount=dao.getMyPageTotalCount();
+	int totalCount=dao.selectMyPageTotalCount();
 	int perPage=5; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -297,7 +297,7 @@ font-size: 14px;
 	no=totalCount-(currentPage-1)*perPage;
 	
 	//페이지에서 보여질 글만 가져오기
-	List<EventDto> list = dao.getmypagelist(startNum, perPage);
+	List<EventDto> list = dao.selectMyPageList(startNum, perPage);
 		
 	//해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
 	//마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상) 리팩터링의 게시판 두 번째 하위도메인 **event(이벤트게시판)**. 직전 병합된 notice(#80)와 구조 동형이라 동일 규칙·강도(full rigor)로 진행했다. **순수 리팩터링(동작 보존)** 이며 기능 변경은 없다.

## 변경 내용 (커밋 4개)
1. **EventDao 위생 정리** — `db` 필드 private화, 죽은 import `notice.model.NoticeDto` 제거(사용처 0건), `// TODO Auto-generated catch block` 11개 제거(printStackTrace 유지), 이중 세미콜론 `;;` 1곳 정정, 들여쓰기 K&R·탭 정규화. `git diff -w`로 토큰 변경 외 0건 확인.
2. **mapRow 추출** — `selectAllEvent`·`selectPagingList`·`selectDataEvent`·`selectMyPageList`의 8컬럼 `ResultSet→EventDto` 매핑 중복을 `private EventDto mapRow(ResultSet)`로 통합.
3. **조회 get\*→select\* 통일 + 호출처 갱신** — DTO getter와 혼동 방지를 위해 조회 접두어를 select\*로 통일:
   - `getAllEvent`→`selectAllEvent`, `getTotalCount`→`selectTotalCount`, `getList`→`selectPagingList`, `getDataEvent`→`selectDataEvent`, `getMyPageTotalCount`→`selectMyPageTotalCount`, `getmypagelist`→`selectMyPageList`(camelCase 정정 동반).
   - 시그니처 불변. 변경/삭제 메서드(insert/update/delete 계열)는 이미 컨벤션 부합이라 미변경.
   - 호출처 11곳/8파일을 **수신자 타입(EventDao 인스턴스) 기준 전수 갱신**: noticevent·main(edao)·eventList·eventChu·eventUpdateForm·eventDetail·eventUpdateAction·admineventlist.
4. **JSP 위생** — 만진 event JSP의 `<title>Insert title here</title>` 잔재 5곳 교체(notice 명명과 일관).

## 동작-중립 근거
- mapRow 통합으로 리스트 조회 3메서드가 기존 미적재하던 `e_image`를 적재하게 되나, 리스트 소비처(noticevent·main·eventList·admineventlist)는 `getE_image()`를 출력하지 않아 동작-중립(notice n_image·회원 searchMem 선례와 동일).
- 타 도메인(qa/qaanswer/review)의 동명 메서드와 공용 레이아웃의 `ndao`(NoticeDao) 호출, DTO snake_case 게터는 미접촉.

## 보안 보존
쓰기/수정/삭제 액션의 로그인 가드·isPost·CSRF(checkCsrf)·관리자/소유자 권한(IDOR 방지)·출력 인코딩(SecurityUtil) 변경 없음. 업로드 이미지 ImageServlet(/fileview) 경유 유지.

## 검증
- `javac`(servlet-api 4.0.1 + WEB-INF/lib, -encoding UTF-8, src/main/java 전체) **매 커밋 EXIT=0**
- `git grep`으로 event 도메인 구식 메서드명 **잔존 0건** 확인(타 도메인 동명은 정상 잔존)
- `/code-review`(high)·`/simplify` 통과 — findings 0건

## ⚠ JSP 런타임 스모크 테스트 필요
JspC/Tomcat 런타임 검증이 이 환경에서 불가하므로, 머지 전 아래 경로 수동 확인 권장:
이벤트 **목록 / 상세 / 작성 / 수정 / 삭제**, 관리자 **이벤트목록 / 일괄삭제**, 메인 페이지 **이벤트 위젯**, 상세의 **추천(chu)** 버튼.

🤖 Generated with [Claude Code](https://claude.com/claude-code)