### PR TITLE
게시판후기(review) 2단계 코드 컨벤션 정리

### DIFF
--- a/src/main/java/review/model/ReviewDao.java
+++ b/src/main/java/review/model/ReviewDao.java
@@ -8,366 +8,340 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mysql.db.DbConnect;
-import notice.model.NoticeDto;
 
 public class ReviewDao {
-	
-	DbConnect db = new DbConnect();
-	
+
+	private DbConnect db = new DbConnect();
+
 	//insert
 	public void insertReview(ReviewDto dto) {
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
-		
+
 		String sql = "insert into reviewboard values(null,?,?,?,?,0,now())";
-	
+
 		try {
 			pstmt = conn.prepareStatement(sql);
-			
-            pstmt.setString(1, dto.getR_myid());
-            pstmt.setString(2, dto.getR_category());;
+
+			pstmt.setString(1, dto.getR_myid());
+			pstmt.setString(2, dto.getR_category());
 			pstmt.setString(3, dto.getR_content());
 			pstmt.setString(4, dto.getR_image());
-			
-			
+
 			pstmt.execute();
-			
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(pstmt, conn);
 		}
 	}
-	
-	
+
 	//noticelist 전체 출력
-		public List<ReviewDto> getAllReview() {
-			List<ReviewDto> list = new ArrayList<ReviewDto>();
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql = "select * from reviewboard order by r_num desc";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				rs = pstmt.executeQuery();
-				
-				while(rs.next()) {
-					
-					ReviewDto dto = new ReviewDto();
-					
-					dto.setR_num(rs.getString("r_num"));
-					dto.setR_myid(rs.getString("r_myid"));
-					dto.setR_category(rs.getString("r_category"));
-					dto.setR_content(rs.getString("r_content"));
-					dto.setR_image(rs.getString("r_image"));
-					dto.setR_chu(rs.getInt("r_chu"));
-					dto.setR_writeday(rs.getTimestamp("r_writeday"));
-					
-					list.add(dto);
-				}
-				
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-					
-			return list;
-			
-		}
-		
-		
-		//전체 페이지수 dto 반환하기
-		public int getTotalCount() {
-			
-			int total = 0;
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql = "select count(*) from reviewboard";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				rs = pstmt.executeQuery();
-				
-				if(rs.next()) {
-					total = rs.getInt(1);
-				}
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-			
-			return total;
-			
-		}
-		
-		// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-		public List<ReviewDto> getList(int start, int perPage) {
-			List<ReviewDto> list = new ArrayList<ReviewDto>();
+	public List<ReviewDto> getAllReview() {
+		List<ReviewDto> list = new ArrayList<ReviewDto>();
 
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
 
-			String sql = "select * from reviewboard order by r_num desc limit ?,?";
+		String sql = "select * from reviewboard order by r_num desc";
 
-			try {
-				pstmt = conn.prepareStatement(sql);
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
 
-				pstmt.setInt(1, start);
-				pstmt.setInt(2, perPage);
+			while (rs.next()) {
 
-				rs = pstmt.executeQuery();
+				ReviewDto dto = new ReviewDto();
 
-				while (rs.next()) {
+				dto.setR_num(rs.getString("r_num"));
+				dto.setR_myid(rs.getString("r_myid"));
+				dto.setR_category(rs.getString("r_category"));
+				dto.setR_content(rs.getString("r_content"));
+				dto.setR_image(rs.getString("r_image"));
+				dto.setR_chu(rs.getInt("r_chu"));
+				dto.setR_writeday(rs.getTimestamp("r_writeday"));
 
-					ReviewDto dto = new ReviewDto();
-
-					dto.setR_num(rs.getString("r_num"));
-					dto.setR_myid(rs.getString("r_myid"));
-					dto.setR_category(rs.getString("r_category"));
-					dto.setR_content(rs.getString("r_content"));
-					dto.setR_image(rs.getString("r_image"));
-					dto.setR_chu(rs.getInt("r_chu"));
-					dto.setR_writeday(rs.getTimestamp("r_writeday"));
-
-					list.add(dto);
-				}
-
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(rs, pstmt, conn);
+				list.add(dto);
 			}
 
-			return list;
-		}
-		
-		
-		// update 수정
-		public void updateReview(ReviewDto dto) {
-
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-
-			String sql = "update reviewboard set r_category=? ,r_content=?, r_image=? where r_num=?";
-
-			try {
-				pstmt = conn.prepareStatement(sql);
-
-				pstmt.setString(1, dto.getR_category());
-				pstmt.setString(2, dto.getR_content());
-				pstmt.setString(3, dto.getR_image());
-				pstmt.setString(4, dto.getR_num());
-
-				pstmt.execute();
-				;
-
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
-
-		}
-				
-		// 삭제하기
-		public void deleteReview(String r_num) {
-
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-
-			String sql = "delete from reviewboard where r_num=?";
-
-			try {
-				pstmt = conn.prepareStatement(sql);
-				pstmt.setString(1, r_num);
-
-				pstmt.execute();
-
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
-
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
 
-		// 추천 클릭 시 추천수 증가 시키기
-		public void updateReviewChu(String r_num) {
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-
-			String sql = "update reviewboard set r_chu=r_chu+1 where r_num=?";
-
-			try {
-				pstmt = conn.prepareStatement(sql);
-
-				pstmt.setString(1, r_num);
-				pstmt.execute();
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
-		}
-		
-		
-		//num값 넘겨주기 -> dto 반환!!
-		public ReviewDto getDataReview(String r_num) {
-			ReviewDto dto = new ReviewDto();
-
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-
-			String sql = "select * from reviewboard where r_num=?";
-
-			try {
-				pstmt = conn.prepareStatement(sql);
-
-				pstmt.setString(1, r_num);
-				rs = pstmt.executeQuery();
-
-				while (rs.next()) {
-
-
-					dto.setR_num(rs.getString("r_num"));
-					dto.setR_myid(rs.getString("r_myid"));
-					dto.setR_category(rs.getString("r_category"));
-					dto.setR_content(rs.getString("r_content"));
-					dto.setR_image(rs.getString("r_image"));
-					dto.setR_chu(rs.getInt("r_chu"));
-					dto.setR_writeday(rs.getTimestamp("r_writeday"));
-
-				}
-
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(rs, pstmt, conn);
-			}
-
-			return dto;
-		}
-		
-		//myid를 통해 r_num값 얻어오기 (soo) (mypage->myactivelist.jsp)
-		public String getNum(String r_myid) {
-			String r_num="";
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql = "select * from reviewboard where r_myid=?";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				pstmt.setString(1, r_myid);
-				rs=pstmt.executeQuery();
-				
-				if(rs.next()) {
-					r_num=rs.getString("r_num");
-				}
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			
-			return r_num;
-		}
-		
-		
-		// myreviewlist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-				public List<ReviewDto> getmypagelist(int start, int perPage, String myid) {
-					List<ReviewDto> mypagelist = new ArrayList<ReviewDto>();
-
-					Connection conn = db.getConnection();
-					PreparedStatement pstmt = null;
-					ResultSet rs = null;
-
-					String sql = "select * from reviewboard where r_myid=? order by r_num desc limit ?,?";
-
-					try {
-						pstmt = conn.prepareStatement(sql);
-						
-						pstmt.setString(1, myid);
-						pstmt.setInt(2, start);
-						pstmt.setInt(3, perPage);
-
-						rs = pstmt.executeQuery();
-
-						while (rs.next()) {
-
-							ReviewDto dto = new ReviewDto();
-
-							dto.setR_num(rs.getString("r_num"));
-							dto.setR_myid(rs.getString("r_myid"));
-							dto.setR_category(rs.getString("r_category"));
-							dto.setR_content(rs.getString("r_content"));
-							dto.setR_image(rs.getString("r_image"));
-							dto.setR_chu(rs.getInt("r_chu"));
-							dto.setR_writeday(rs.getTimestamp("r_writeday"));
-
-							mypagelist.add(dto);
-						}
-
-					} catch (SQLException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					} finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-
-					return mypagelist;
-				}
-				// myreviewlist.jsp //페이징리스트/ 전체페이지수 반환하기
-				public int getMyPageTotalCount(String myid) {
-					
-					int total = 0;
-					
-					Connection conn = db.getConnection();
-					PreparedStatement pstmt = null;
-					ResultSet rs = null;
-					
-					String sql = "select count(*) from reviewboard where r_myid=?";
-					
-					try {
-						pstmt = conn.prepareStatement(sql);
-						pstmt.setString(1, myid);
-						rs = pstmt.executeQuery();
-						
-						if(rs.next()) {
-							total = rs.getInt(1);
-						}
-						
-					} catch (SQLException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}finally {
-						db.dbClose(rs, pstmt, conn);
-					}
-					
-					return total;
-					
-				}
-				
+		return list;
 	}
 
+	//전체 페이지수 dto 반환하기
+	public int getTotalCount() {
+
+		int total = 0;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from reviewboard";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
+
+			if (rs.next()) {
+				total = rs.getInt(1);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+	}
+
+	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
+	public List<ReviewDto> getList(int start, int perPage) {
+		List<ReviewDto> list = new ArrayList<ReviewDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from reviewboard order by r_num desc limit ?,?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setInt(1, start);
+			pstmt.setInt(2, perPage);
+
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+
+				ReviewDto dto = new ReviewDto();
+
+				dto.setR_num(rs.getString("r_num"));
+				dto.setR_myid(rs.getString("r_myid"));
+				dto.setR_category(rs.getString("r_category"));
+				dto.setR_content(rs.getString("r_content"));
+				dto.setR_image(rs.getString("r_image"));
+				dto.setR_chu(rs.getInt("r_chu"));
+				dto.setR_writeday(rs.getTimestamp("r_writeday"));
+
+				list.add(dto);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return list;
+	}
+
+	// update 수정
+	public void updateReview(ReviewDto dto) {
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update reviewboard set r_category=? ,r_content=?, r_image=? where r_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getR_category());
+			pstmt.setString(2, dto.getR_content());
+			pstmt.setString(3, dto.getR_image());
+			pstmt.setString(4, dto.getR_num());
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	// 삭제하기
+	public void deleteReview(String r_num) {
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "delete from reviewboard where r_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, r_num);
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	// 추천 클릭 시 추천수 증가 시키기
+	public void updateReviewChu(String r_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "update reviewboard set r_chu=r_chu+1 where r_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, r_num);
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	//num값 넘겨주기 -> dto 반환!!
+	public ReviewDto getDataReview(String r_num) {
+		ReviewDto dto = new ReviewDto();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from reviewboard where r_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, r_num);
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+
+				dto.setR_num(rs.getString("r_num"));
+				dto.setR_myid(rs.getString("r_myid"));
+				dto.setR_category(rs.getString("r_category"));
+				dto.setR_content(rs.getString("r_content"));
+				dto.setR_image(rs.getString("r_image"));
+				dto.setR_chu(rs.getInt("r_chu"));
+				dto.setR_writeday(rs.getTimestamp("r_writeday"));
+
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return dto;
+	}
+
+	//myid를 통해 r_num값 얻어오기 (soo) (mypage->myactivelist.jsp)
+	public String getNum(String r_myid) {
+		String r_num = "";
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from reviewboard where r_myid=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, r_myid);
+			rs = pstmt.executeQuery();
+
+			if (rs.next()) {
+				r_num = rs.getString("r_num");
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+
+		return r_num;
+	}
+
+	// myreviewlist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
+	public List<ReviewDto> getmypagelist(int start, int perPage, String myid) {
+		List<ReviewDto> mypagelist = new ArrayList<ReviewDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from reviewboard where r_myid=? order by r_num desc limit ?,?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setString(1, myid);
+			pstmt.setInt(2, start);
+			pstmt.setInt(3, perPage);
+
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+
+				ReviewDto dto = new ReviewDto();
+
+				dto.setR_num(rs.getString("r_num"));
+				dto.setR_myid(rs.getString("r_myid"));
+				dto.setR_category(rs.getString("r_category"));
+				dto.setR_content(rs.getString("r_content"));
+				dto.setR_image(rs.getString("r_image"));
+				dto.setR_chu(rs.getInt("r_chu"));
+				dto.setR_writeday(rs.getTimestamp("r_writeday"));
+
+				mypagelist.add(dto);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return mypagelist;
+	}
+
+	// myreviewlist.jsp //페이징리스트/ 전체페이지수 반환하기
+	public int getMyPageTotalCount(String myid) {
+
+		int total = 0;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from reviewboard where r_myid=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, myid);
+			rs = pstmt.executeQuery();
+
+			if (rs.next()) {
+				total = rs.getInt(1);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+	}
+
+}

--- a/src/main/java/review/model/ReviewDao.java
+++ b/src/main/java/review/model/ReviewDao.java
@@ -39,7 +39,7 @@ public class ReviewDao {
 	}
 
 	//전체 페이지수 dto 반환하기
-	public int getTotalCount() {
+	public int selectTotalCount() {
 
 		int total = 0;
 
@@ -67,7 +67,7 @@ public class ReviewDao {
 	}
 
 	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<ReviewDto> getList(int start, int perPage) {
+	public List<ReviewDto> selectPagingList(int start, int perPage) {
 		List<ReviewDto> list = new ArrayList<ReviewDto>();
 
 		Connection conn = db.getConnection();
@@ -163,7 +163,7 @@ public class ReviewDao {
 	}
 
 	//num값 넘겨주기 -> dto 반환!!
-	public ReviewDto getDataReview(String r_num) {
+	public ReviewDto selectDataReview(String r_num) {
 		ReviewDto dto = new ReviewDto();
 
 		Connection conn = db.getConnection();
@@ -192,7 +192,7 @@ public class ReviewDao {
 	}
 
 	// myreviewlist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<ReviewDto> getmypagelist(int start, int perPage, String myid) {
+	public List<ReviewDto> selectMyPageList(int start, int perPage, String myid) {
 		List<ReviewDto> mypagelist = new ArrayList<ReviewDto>();
 
 		Connection conn = db.getConnection();
@@ -224,7 +224,7 @@ public class ReviewDao {
 	}
 
 	// myreviewlist.jsp //페이징리스트/ 전체페이지수 반환하기
-	public int getMyPageTotalCount(String myid) {
+	public int selectMyPageTotalCount(String myid) {
 
 		int total = 0;
 

--- a/src/main/java/review/model/ReviewDao.java
+++ b/src/main/java/review/model/ReviewDao.java
@@ -85,18 +85,7 @@ public class ReviewDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				ReviewDto dto = new ReviewDto();
-
-				dto.setR_num(rs.getString("r_num"));
-				dto.setR_myid(rs.getString("r_myid"));
-				dto.setR_category(rs.getString("r_category"));
-				dto.setR_content(rs.getString("r_content"));
-				dto.setR_image(rs.getString("r_image"));
-				dto.setR_chu(rs.getInt("r_chu"));
-				dto.setR_writeday(rs.getTimestamp("r_writeday"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -190,15 +179,7 @@ public class ReviewDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				dto.setR_num(rs.getString("r_num"));
-				dto.setR_myid(rs.getString("r_myid"));
-				dto.setR_category(rs.getString("r_category"));
-				dto.setR_content(rs.getString("r_content"));
-				dto.setR_image(rs.getString("r_image"));
-				dto.setR_chu(rs.getInt("r_chu"));
-				dto.setR_writeday(rs.getTimestamp("r_writeday"));
-
+				dto = mapRow(rs);
 			}
 
 		} catch (SQLException e) {
@@ -230,18 +211,7 @@ public class ReviewDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				ReviewDto dto = new ReviewDto();
-
-				dto.setR_num(rs.getString("r_num"));
-				dto.setR_myid(rs.getString("r_myid"));
-				dto.setR_category(rs.getString("r_category"));
-				dto.setR_content(rs.getString("r_content"));
-				dto.setR_image(rs.getString("r_image"));
-				dto.setR_chu(rs.getInt("r_chu"));
-				dto.setR_writeday(rs.getTimestamp("r_writeday"));
-
-				mypagelist.add(dto);
+				mypagelist.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -280,6 +250,21 @@ public class ReviewDao {
 		}
 
 		return total;
+	}
+
+	// ResultSet 한 행을 ReviewDto로 매핑(조회 메서드 공용)
+	private ReviewDto mapRow(ResultSet rs) throws SQLException {
+		ReviewDto dto = new ReviewDto();
+
+		dto.setR_num(rs.getString("r_num"));
+		dto.setR_myid(rs.getString("r_myid"));
+		dto.setR_category(rs.getString("r_category"));
+		dto.setR_content(rs.getString("r_content"));
+		dto.setR_image(rs.getString("r_image"));
+		dto.setR_chu(rs.getInt("r_chu"));
+		dto.setR_writeday(rs.getTimestamp("r_writeday"));
+
+		return dto;
 	}
 
 }

--- a/src/main/java/review/model/ReviewDao.java
+++ b/src/main/java/review/model/ReviewDao.java
@@ -38,44 +38,6 @@ public class ReviewDao {
 		}
 	}
 
-	//noticelist 전체 출력
-	public List<ReviewDto> getAllReview() {
-		List<ReviewDto> list = new ArrayList<ReviewDto>();
-
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-
-		String sql = "select * from reviewboard order by r_num desc";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			rs = pstmt.executeQuery();
-
-			while (rs.next()) {
-
-				ReviewDto dto = new ReviewDto();
-
-				dto.setR_num(rs.getString("r_num"));
-				dto.setR_myid(rs.getString("r_myid"));
-				dto.setR_category(rs.getString("r_category"));
-				dto.setR_content(rs.getString("r_content"));
-				dto.setR_image(rs.getString("r_image"));
-				dto.setR_chu(rs.getInt("r_chu"));
-				dto.setR_writeday(rs.getTimestamp("r_writeday"));
-
-				list.add(dto);
-			}
-
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-
-		return list;
-	}
-
 	//전체 페이지수 dto 반환하기
 	public int getTotalCount() {
 
@@ -246,30 +208,6 @@ public class ReviewDao {
 		}
 
 		return dto;
-	}
-
-	//myid를 통해 r_num값 얻어오기 (soo) (mypage->myactivelist.jsp)
-	public String getNum(String r_myid) {
-		String r_num = "";
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-
-		String sql = "select * from reviewboard where r_myid=?";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, r_myid);
-			rs = pstmt.executeQuery();
-
-			if (rs.next()) {
-				r_num = rs.getString("r_num");
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		}
-
-		return r_num;
 	}
 
 	// myreviewlist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)

--- a/src/main/java/review/model/ReviewDto.java
+++ b/src/main/java/review/model/ReviewDto.java
@@ -2,8 +2,6 @@ package review.model;
 
 import java.sql.Timestamp;
 
-import javax.management.loading.PrivateClassLoader;
-
 public class ReviewDto {
 	
 	private String r_num;

--- a/src/main/webapp/mypage/deletereview.jsp
+++ b/src/main/webapp/mypage/deletereview.jsp
@@ -5,7 +5,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Insert title here</title>
+<title>후기 삭제</title>
 </head>
 <body>
 <%

--- a/src/main/webapp/mypage/deletereview.jsp
+++ b/src/main/webapp/mypage/deletereview.jsp
@@ -23,7 +23,7 @@
 	ReviewDao dao=new ReviewDao();
 	for(String n:num)
 	{
-		review.model.ReviewDto r=dao.getDataReview(n);
+		review.model.ReviewDto r=dao.selectDataReview(n);
 		if(r!=null && util.SecurityUtil.isOwnerOrAdmin(session, r.getR_myid())){
 			dao.deleteReview(n);
 		}

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -257,7 +257,7 @@ String myid = (String) session.getAttribute("myid");
 ReviewDao dao = new ReviewDao();
 
 //전체갯수
-int totalCount = dao.getMyPageTotalCount(myid);
+int totalCount = dao.selectMyPageTotalCount(myid);
 int perPage = 5; //한페이지당 보여질 글의 갯수
 int perBlock = 10; //한블럭당 보여질 페이지 갯수
 int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -297,7 +297,7 @@ startNum = (currentPage - 1) * perPage;
 no = totalCount - (currentPage - 1) * perPage;
 
 //페이지에서 보여질 글만 가져오기
-List<ReviewDto> list = dao.getmypagelist(startNum, perPage, myid);
+List<ReviewDto> list = dao.selectMyPageList(startNum, perPage, myid);
 
 //해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
 //마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -18,7 +18,7 @@
 <link rel="stylesheet"
 	href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>내 후기</title>
 <style type="text/css">
 ul.tabs {
 	margin: 0px;

--- a/src/main/webapp/reviewboard/reviewChu.jsp
+++ b/src/main/webapp/reviewboard/reviewChu.jsp
@@ -18,7 +18,7 @@
     dao.updateReviewChu(r_num);
     
     //증가된 chu 값 json 형태로 보내기
-    int chu = dao.getDataReview(r_num).getR_chu();
+    int chu = dao.selectDataReview(r_num).getR_chu();
     
     JSONObject ob = new JSONObject();
     ob.put("chu", chu);

--- a/src/main/webapp/reviewboard/reviewDelete.jsp
+++ b/src/main/webapp/reviewboard/reviewDelete.jsp
@@ -26,7 +26,7 @@
 
     //db로 부터 저장된 이미지명 얻기
     ReviewDao dao = new ReviewDao();
-    ReviewDto old = dao.getDataReview(r_num);
+    ReviewDto old = dao.selectDataReview(r_num);
 
     // 로그인 + 작성자 본인(또는 관리자)만 삭제 가능
     if(!util.SecurityUtil.isLogin(session) || old==null

--- a/src/main/webapp/reviewboard/reviewDelete.jsp
+++ b/src/main/webapp/reviewboard/reviewDelete.jsp
@@ -11,7 +11,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>후기 삭제</title>
 </head>
 <body>
 

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -13,7 +13,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>후기게시판</title>
 <style type="text/css">
 
   span.day{

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -163,7 +163,7 @@
 	ReviewDao dao=new ReviewDao();
 	
 	//전체갯수
-	int totalCount=dao.getTotalCount();
+	int totalCount=dao.selectTotalCount();
 	int perPage=5; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -203,7 +203,7 @@
 	no=totalCount-(currentPage-1)*perPage;
 	
 	//페이지에서 보여질 글만 가져오기
-	List<ReviewDto> list = dao.getList(startNum, perPage);
+	List<ReviewDto> list = dao.selectPagingList(startNum, perPage);
 		
 	//해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
 	//마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정

--- a/src/main/webapp/reviewboard/reviewUpdateAction.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateAction.jsp
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>후기 수정</title>
 </head>
 <body>
 

--- a/src/main/webapp/reviewboard/reviewUpdateAction.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateAction.jsp
@@ -63,7 +63,7 @@
 
 		//기존포토명 가져오기 -> 기존에 사진값을 가져오기 위해서 dao 먼저 선언
 		ReviewDao dao = new ReviewDao();
-		ReviewDto old = dao.getDataReview(r_num);
+		ReviewDto old = dao.selectDataReview(r_num);
 		String old_photoName = old.getR_image();
 
 		//작성자 본인 또는 관리자만 수정 가능

--- a/src/main/webapp/reviewboard/reviewUpdateForm.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateForm.jsp
@@ -58,7 +58,7 @@
    String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    ReviewDao dao = new ReviewDao();
-   ReviewDto dto = dao.getDataReview(r_num);
+   ReviewDto dto = dao.selectDataReview(r_num);
    
   
    HugesoInfoDao hdao = new HugesoInfoDao();

--- a/src/main/webapp/reviewboard/reviewUpdateForm.jsp
+++ b/src/main/webapp/reviewboard/reviewUpdateForm.jsp
@@ -13,7 +13,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>후기 수정</title>
 <style type="text/css">
 
   button.col {


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상) 리팩터링의 게시판 하위도메인 세 번째 — **review(후기게시판)**. notice(#80)·event(#81)와 동일 규칙·강도(full rigor)로 진행. 동작 보존이 원칙이며 보안(로그인 가드·CSRF·IDOR·출력 인코딩)은 일절 약화하지 않음.

## 변경 내용 (커밋 5단계)
1. **ReviewDao·ReviewDto 위생** — db 필드 private화, 죽은 import 2개(`notice.model.NoticeDto`, `javax.management.loading.PrivateClassLoader`) 제거, `// TODO Auto-generated catch block` 주석 제거, 이중·잉여 세미콜론 2곳(insertReview `;;`·updateReview 홀 `;`) 제거, 들여쓰기 정규화(탭+K&R).
2. **죽은 코드 제거** — `getAllReview()`·`getNum()`(둘 다 전체 레포 참조 0건 재확인 후 삭제).
3. **mapRow 추출** — selectPagingList·selectDataReview·selectMyPageList의 7컬럼 매핑을 `private ReviewDto mapRow(ResultSet)`로 통합(세 메서드 모두 이미 r_image 적재 → 동작 중립).
4. **조회 get*→select* 통일 + 호출처 갱신** — getTotalCount→selectTotalCount / getList→selectPagingList / getDataReview→selectDataReview / getmypagelist→selectMyPageList / getMyPageTotalCount→selectMyPageTotalCount(시그니처 불변, myid 보존). 호출처 9곳/7파일(reviewboard 5 + mypage 2) 수신자 타입 기준 전수 갱신.
5. **JSP title 위생** — 만진 6개 JSP의 `<title>Insert title here</title>` 교체.

## 검증
- 각 단계 `javac` 전체 컴파일 **EXIT=0**.
- `git diff -w`로 위생 커밋의 토큰 변경 외 0건 확인.
- `/code-review`(high) — 버그 findings 0건.
- `/simplify`(4각도: reuse/simplification/efficiency/altitude) — 실질 findings 0건.
- 동명 메서드를 가진 qa/qaanswer DAO 호출은 수신자 타입으로 구분해 **미접촉**(qaList·adminqnalist·myqnalist 그대로).

## 주의 사항
- `selectDataReview`의 단일행 `while(rs.next()){ dto=mapRow(rs); }`는 notice/event 선례와 동일 패턴이라 일관성·범위 보존을 위해 `if`로 바꾸지 않고 유지함.
- DTO getter는 DB 컬럼 snake_case 미러링 유지(`getR_num` 등 변경 금지). JSP 파일명 일괄 rename 안 함.

## ⚠ 런타임 스모크 테스트 필요
JSP는 javac로 검증되지 않으므로 머지 전 Tomcat에서 아래 흐름 확인 권장:
- 후기 **목록**(reviewList) / **상세** / **작성** / **수정**(reviewUpdateForm·Action) / **삭제**(reviewDelete)
- 마이페이지 **내 후기 목록**(myreviewlist) / **개별·일괄 삭제**(deletereview)
- 후기 **추천**(reviewChu, ajax chu +1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
