### PR TITLE
게시판 QnA(qa) 도메인 2단계 리팩터링 (코드 컨벤션·유지보수성)

### DIFF
--- a/src/main/java/qa/model/QaDao.java
+++ b/src/main/java/qa/model/QaDao.java
@@ -8,42 +8,38 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mysql.db.DbConnect;
-import notice.model.NoticeDto;
-import review.model.ReviewDto;
 
 public class QaDao {
-	
-	DbConnect db = new DbConnect();
-	
-	
+
+	private DbConnect db = new DbConnect();
+
 	//insert
 	public void insertQa(QaDto dto) {
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
-		
+
 		String sql = "insert into qaboard values(null,?,?,?,?,0,now())";
-		
+
 		try {
 			pstmt = conn.prepareStatement(sql);
-			
+
 			pstmt.setString(1, dto.getQ_myid());
 			pstmt.setString(2, dto.getQ_category());
 			pstmt.setString(3, dto.getQ_subject());
 			pstmt.setString(4, dto.getQ_content());
-			
+
 			pstmt.execute();
-			
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}finally {
+		} finally {
 			db.dbClose(pstmt, conn);
 		}
-				
+
 	}
-  
-  //전체 리스트 출력
+
+	//전체 리스트 출력
 	public List<QaDto> getAllQa() {
 		List<QaDto> list = new ArrayList<QaDto>();
 
@@ -73,7 +69,6 @@ public class QaDao {
 			}
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -82,86 +77,84 @@ public class QaDao {
 		return list;
 
 	}
-	
+
 	// myqalist.jsp //페이징리스트/ 전체페이지수 반환하기
 	public int getMyPageTotalCount(String myid) {
-      
-    int total = 0;
-		
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-  
-    String sql = "select count(*) from qaboard where q_myid=?";
-		
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, myid);
-      rs = pstmt.executeQuery();
-			
-			if(rs.next()) {
-				total = rs.getInt(1);
-			}
-			
-		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-		
-		return total;
-		
-	}
-	
-	//전체 페이지수 dto 반환하기
-	public int getTotalCount() {
-		
+
 		int total = 0;
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-  
-		String sql = "select count(*) from qaboard";
-		
-		try {
-			pstmt = conn.prepareStatement(sql);
-			rs = pstmt.executeQuery();
-			
-			if(rs.next()) {
-				total = rs.getInt(1);
-			}
-			
-		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-		
-		return total;
-		
-	}
-	
-	// myqalist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<QaDto> getmypagelist(int start, int perPage, String myid) {
-		List<QaDto> mypagelist = new ArrayList<QaDto>();
-  
-    Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-  
-    String sql = "select * from qaboard where q_myid=? order by q_num desc limit ?,?";
+
+		String sql = "select count(*) from qaboard where q_myid=?";
 
 		try {
 			pstmt = conn.prepareStatement(sql);
-			
+			pstmt.setString(1, myid);
+			rs = pstmt.executeQuery();
+
+			if (rs.next()) {
+				total = rs.getInt(1);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+
+	}
+
+	//전체 페이지수 dto 반환하기
+	public int getTotalCount() {
+
+		int total = 0;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from qaboard";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
+
+			if (rs.next()) {
+				total = rs.getInt(1);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return total;
+
+	}
+
+	// myqalist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
+	public List<QaDto> getmypagelist(int start, int perPage, String myid) {
+		List<QaDto> mypagelist = new ArrayList<QaDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from qaboard where q_myid=? order by q_num desc limit ?,?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
 			pstmt.setString(1, myid);
 			pstmt.setInt(2, start);
 			pstmt.setInt(3, perPage);
-      
-      rs = pstmt.executeQuery();
+
+			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
 
@@ -174,18 +167,17 @@ public class QaDao {
 				dto.setQ_content(rs.getString("q_content"));
 				dto.setQ_readcount(rs.getInt("q_readcount"));
 				dto.setQ_writeday(rs.getTimestamp("q_writeday"));
-        
-        mypagelist.add(dto);
-      }
-      } catch (SQLException e) {
-			// TODO Auto-generated catch block
+
+				mypagelist.add(dto);
+			}
+		} catch (SQLException e) {
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-    return mypagelist;
+		return mypagelist;
 	}
-  
+
 	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
 	public List<QaDto> getList(int start, int perPage) {
 		List<QaDto> list = new ArrayList<QaDto>();
@@ -193,13 +185,13 @@ public class QaDao {
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-  
-    //String sql = "select * from qaboard order by q_num desc limit ?,?";
-		
+
+		//String sql = "select * from qaboard order by q_num desc limit ?,?";
+
 		String sql = "select a.q_num, a.q_myid,a.q_category,a.q_subject,a.q_content,a.q_readcount,a.q_writeday"
 				+ "       ,(select count(1) from qaanswerboard as b where b.q_num = a.q_num) AS qa_cnt"
 				+ " from qaboard as a order by q_num desc limit ?,?";
-  
+
 		try {
 			pstmt = conn.prepareStatement(sql);
 
@@ -219,44 +211,42 @@ public class QaDao {
 				dto.setQ_content(rs.getString("q_content"));
 				dto.setQ_readcount(rs.getInt("q_readcount"));
 				dto.setQ_writeday(rs.getTimestamp("q_writeday"));
-        
+
 				//dto.setQa_cnt(rs.getInt("qa_cnt"));
 
 				list.add(dto);
 			}
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
-    return list;
+		return list;
 	}
-	
-			// 삭제하기
-			public void deleteQna(String q_num) {
 
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
+	// 삭제하기
+	public void deleteQna(String q_num) {
 
-				String sql = "delete from qaboard where q_num=?";
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
 
-				try {
-					pstmt = conn.prepareStatement(sql);
-					pstmt.setString(1, q_num);
+		String sql = "delete from qaboard where q_num=?";
 
-					pstmt.execute();
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, q_num);
 
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				} finally {
-					db.dbClose(pstmt, conn);
-				}
+			pstmt.execute();
 
-			}
-	
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+
+	}
+
 	// detail페이지 num값 넘겨주기 -> dto 반환!!
 	public QaDto getDataQa(String q_num) {
 		QaDto dto = new QaDto();
@@ -286,7 +276,6 @@ public class QaDao {
 			}
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -294,9 +283,7 @@ public class QaDao {
 
 		return dto;
 	}
-	
-	
-	
+
 	// readcount 해주기 / 조회수 및 추천
 	public void updateReadcount(String q_num) {
 		Connection conn = db.getConnection();
@@ -310,13 +297,11 @@ public class QaDao {
 			pstmt.execute();
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
 		}
 	}
-	
 
 	// update 수정
 	public void updateQa(QaDto dto) {
@@ -335,10 +320,8 @@ public class QaDao {
 			pstmt.setString(4, dto.getQ_num());
 
 			pstmt.execute();
-			
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -361,7 +344,6 @@ public class QaDao {
 			pstmt.execute();
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);

--- a/src/main/java/qa/model/QaDao.java
+++ b/src/main/java/qa/model/QaDao.java
@@ -181,28 +181,6 @@ public class QaDao {
 		return list;
 	}
 
-	// 삭제하기
-	public void deleteQna(String q_num) {
-
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-
-		String sql = "delete from qaboard where q_num=?";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, q_num);
-
-			pstmt.execute();
-
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(pstmt, conn);
-		}
-
-	}
-
 	// detail페이지 num값 넘겨주기 -> dto 반환!!
 	public QaDto getDataQa(String q_num) {
 		QaDto dto = new QaDto();

--- a/src/main/java/qa/model/QaDao.java
+++ b/src/main/java/qa/model/QaDao.java
@@ -40,7 +40,7 @@ public class QaDao {
 	}
 
 	// myqalist.jsp //페이징리스트/ 전체페이지수 반환하기
-	public int getMyPageTotalCount(String myid) {
+	public int selectMyPageTotalCount(String myid) {
 
 		int total = 0;
 
@@ -70,7 +70,7 @@ public class QaDao {
 	}
 
 	//전체 페이지수 dto 반환하기
-	public int getTotalCount() {
+	public int selectTotalCount() {
 
 		int total = 0;
 
@@ -99,7 +99,7 @@ public class QaDao {
 	}
 
 	// myqalist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<QaDto> getmypagelist(int start, int perPage, String myid) {
+	public List<QaDto> selectMyPageList(int start, int perPage, String myid) {
 		List<QaDto> mypagelist = new ArrayList<QaDto>();
 
 		Connection conn = db.getConnection();
@@ -129,7 +129,7 @@ public class QaDao {
 	}
 
 	// paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<QaDto> getList(int start, int perPage) {
+	public List<QaDto> selectPagingList(int start, int perPage) {
 		List<QaDto> list = new ArrayList<QaDto>();
 
 		Connection conn = db.getConnection();
@@ -160,7 +160,7 @@ public class QaDao {
 	}
 
 	// detail페이지 num값 넘겨주기 -> dto 반환!!
-	public QaDto getDataQa(String q_num) {
+	public QaDto selectDataQa(String q_num) {
 		QaDto dto = new QaDto();
 
 		Connection conn = db.getConnection();

--- a/src/main/java/qa/model/QaDao.java
+++ b/src/main/java/qa/model/QaDao.java
@@ -39,45 +39,6 @@ public class QaDao {
 
 	}
 
-	//전체 리스트 출력
-	public List<QaDto> getAllQa() {
-		List<QaDto> list = new ArrayList<QaDto>();
-
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-
-		String sql = "select * from qaboard order by q_num desc";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			rs = pstmt.executeQuery();
-
-			while (rs.next()) {
-
-				QaDto dto = new QaDto();
-
-				dto.setQ_num(rs.getString("q_num"));
-				dto.setQ_myid(rs.getString("q_myid"));
-				dto.setQ_category(rs.getString("q_category"));
-				dto.setQ_subject(rs.getString("q_subject"));
-				dto.setQ_content(rs.getString("q_content"));
-				dto.setQ_readcount(rs.getInt("q_readcount"));
-				dto.setQ_writeday(rs.getTimestamp("q_writeday"));
-
-				list.add(dto);
-			}
-
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-
-		return list;
-
-	}
-
 	// myqalist.jsp //페이징리스트/ 전체페이지수 반환하기
 	public int getMyPageTotalCount(String myid) {
 
@@ -186,11 +147,8 @@ public class QaDao {
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
 
-		//String sql = "select * from qaboard order by q_num desc limit ?,?";
-
-		String sql = "select a.q_num, a.q_myid,a.q_category,a.q_subject,a.q_content,a.q_readcount,a.q_writeday"
-				+ "       ,(select count(1) from qaanswerboard as b where b.q_num = a.q_num) AS qa_cnt"
-				+ " from qaboard as a order by q_num desc limit ?,?";
+		String sql = "select q_num, q_myid, q_category, q_subject, q_content, q_readcount, q_writeday"
+				+ " from qaboard order by q_num desc limit ?,?";
 
 		try {
 			pstmt = conn.prepareStatement(sql);
@@ -211,8 +169,6 @@ public class QaDao {
 				dto.setQ_content(rs.getString("q_content"));
 				dto.setQ_readcount(rs.getInt("q_readcount"));
 				dto.setQ_writeday(rs.getTimestamp("q_writeday"));
-
-				//dto.setQa_cnt(rs.getInt("qa_cnt"));
 
 				list.add(dto);
 			}

--- a/src/main/java/qa/model/QaDao.java
+++ b/src/main/java/qa/model/QaDao.java
@@ -118,18 +118,7 @@ public class QaDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				QaDto dto = new QaDto();
-
-				dto.setQ_num(rs.getString("q_num"));
-				dto.setQ_myid(rs.getString("q_myid"));
-				dto.setQ_category(rs.getString("q_category"));
-				dto.setQ_subject(rs.getString("q_subject"));
-				dto.setQ_content(rs.getString("q_content"));
-				dto.setQ_readcount(rs.getInt("q_readcount"));
-				dto.setQ_writeday(rs.getTimestamp("q_writeday"));
-
-				mypagelist.add(dto);
+				mypagelist.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -159,18 +148,7 @@ public class QaDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				QaDto dto = new QaDto();
-
-				dto.setQ_num(rs.getString("q_num"));
-				dto.setQ_myid(rs.getString("q_myid"));
-				dto.setQ_category(rs.getString("q_category"));
-				dto.setQ_subject(rs.getString("q_subject"));
-				dto.setQ_content(rs.getString("q_content"));
-				dto.setQ_readcount(rs.getInt("q_readcount"));
-				dto.setQ_writeday(rs.getTimestamp("q_writeday"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -198,15 +176,7 @@ public class QaDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				dto.setQ_num(rs.getString("q_num"));
-				dto.setQ_myid(rs.getString("q_myid"));
-				dto.setQ_category(rs.getString("q_category"));
-				dto.setQ_subject(rs.getString("q_subject"));
-				dto.setQ_content(rs.getString("q_content"));
-				dto.setQ_readcount(rs.getInt("q_readcount"));
-				dto.setQ_writeday(rs.getTimestamp("q_writeday"));
-
+				dto = mapRow(rs);
 			}
 
 		} catch (SQLException e) {
@@ -283,5 +253,20 @@ public class QaDao {
 			db.dbClose(pstmt, conn);
 		}
 
+	}
+
+	// ResultSet 한 행을 QaDto로 매핑 (조회 메서드 공통)
+	private QaDto mapRow(ResultSet rs) throws SQLException {
+		QaDto dto = new QaDto();
+
+		dto.setQ_num(rs.getString("q_num"));
+		dto.setQ_myid(rs.getString("q_myid"));
+		dto.setQ_category(rs.getString("q_category"));
+		dto.setQ_subject(rs.getString("q_subject"));
+		dto.setQ_content(rs.getString("q_content"));
+		dto.setQ_readcount(rs.getInt("q_readcount"));
+		dto.setQ_writeday(rs.getTimestamp("q_writeday"));
+
+		return dto;
 	}
 }

--- a/src/main/webapp/mypage/deleteqna.jsp
+++ b/src/main/webapp/mypage/deleteqna.jsp
@@ -28,7 +28,7 @@
 	{
 		qa.model.QaDto q=dao.getDataQa(n);
 		if(q!=null && util.SecurityUtil.isOwnerOrAdmin(session, q.getQ_myid())){
-			dao.deleteQna(n);
+			dao.deleteQa(n);
 		}
 	}
 	

--- a/src/main/webapp/mypage/deleteqna.jsp
+++ b/src/main/webapp/mypage/deleteqna.jsp
@@ -8,7 +8,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Dongle&family=Nanum+Pen+Script&family=Noto+Sans+KR:wght@100..900&family=Single+Day&family=Stylish&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>내 문의 삭제</title>
 </head>
 <body>
 <%

--- a/src/main/webapp/mypage/deleteqna.jsp
+++ b/src/main/webapp/mypage/deleteqna.jsp
@@ -26,7 +26,7 @@
 	QaDao dao=new QaDao();
 	for(String n:num)
 	{
-		qa.model.QaDto q=dao.getDataQa(n);
+		qa.model.QaDto q=dao.selectDataQa(n);
 		if(q!=null && util.SecurityUtil.isOwnerOrAdmin(session, q.getQ_myid())){
 			dao.deleteQa(n);
 		}

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -253,7 +253,7 @@ font-size: 14px;
    QaDao dao=new QaDao();
    
    //전체갯수
-   int totalCount=dao.getMyPageTotalCount(myid);
+   int totalCount=dao.selectMyPageTotalCount(myid);
    int perPage=5; //한페이지당 보여질 글의 갯수
    int perBlock=10; //한블럭당 보여질 페이지 갯수
    int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -293,7 +293,7 @@ font-size: 14px;
    no=totalCount-(currentPage-1)*perPage;
    
    //페이지에서 보여질 글만 가져오기
-   List<QaDto> list = dao.getmypagelist(startNum, perPage, myid);
+   List<QaDto> list = dao.selectMyPageList(startNum, perPage, myid);
       
    //해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
    //마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -15,7 +15,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>내 문의 목록</title>
 <style type="text/css">
 ul.tabs {
    margin: 0px;

--- a/src/main/webapp/qaboard/qaDelete.jsp
+++ b/src/main/webapp/qaboard/qaDelete.jsp
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>QnA 삭제</title>
 </head>
 <body>
 

--- a/src/main/webapp/qaboard/qaDelete.jsp
+++ b/src/main/webapp/qaboard/qaDelete.jsp
@@ -23,7 +23,7 @@
     QaDao dao = new QaDao();
 
     // 로그인 + 작성자 본인(또는 관리자)만 삭제 가능
-    qa.model.QaDto old = dao.getDataQa(q_num);
+    qa.model.QaDto old = dao.selectDataQa(q_num);
     if(!util.SecurityUtil.isLogin(session) || old==null
             || !util.SecurityUtil.isOwnerOrAdmin(session, old.getQ_myid())){
 %>

--- a/src/main/webapp/qaboard/qaDetail.jsp
+++ b/src/main/webapp/qaboard/qaDetail.jsp
@@ -11,7 +11,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>QnA 상세보기</title>
 <%
 //로그인 세션얻기
 String loginok = (String) session.getAttribute("loginok");

--- a/src/main/webapp/qaboard/qaDetail.jsp
+++ b/src/main/webapp/qaboard/qaDetail.jsp
@@ -19,7 +19,7 @@ String myid=(String)session.getAttribute("myid");
 String q_num = util.SecurityUtil.digitsOnly(request.getParameter("q_num"));
 QaDao dao = new QaDao();
 
-QaDto dto = dao.getDataQa(q_num);
+QaDto dto = dao.selectDataQa(q_num);
 String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
 
 //조회수 가져오기

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -124,7 +124,7 @@
 	QaDao dao=new QaDao();
 	
 	//전체갯수
-	int totalCount=dao.getTotalCount();
+	int totalCount=dao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -164,7 +164,7 @@
 	no=totalCount-(currentPage-1)*perPage;
 	
 	//페이지에서 보여질 글만 가져오기
-	List<QaDto> list = dao.getList(startNum, perPage);
+	List<QaDto> list = dao.selectPagingList(startNum, perPage);
 		
 	//해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
 	//마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>QnA 게시판</title>
 <style type="text/css">
 
   button.col {

--- a/src/main/webapp/qaboard/qaUpdateAction.jsp
+++ b/src/main/webapp/qaboard/qaUpdateAction.jsp
@@ -38,7 +38,7 @@
     QaDao dao = new QaDao();
 
     // 로그인 + 작성자 본인(또는 관리자)만 수정 가능
-    QaDto old = dao.getDataQa(q_num);
+    QaDto old = dao.selectDataQa(q_num);
     if(!util.SecurityUtil.isLogin(session) || old==null
             || !util.SecurityUtil.isOwnerOrAdmin(session, old.getQ_myid())){
 %>

--- a/src/main/webapp/qaboard/qaUpdateAction.jsp
+++ b/src/main/webapp/qaboard/qaUpdateAction.jsp
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>QnA 수정 처리</title>
 </head>
 <body>
   <%

--- a/src/main/webapp/qaboard/qaUpdateForm.jsp
+++ b/src/main/webapp/qaboard/qaUpdateForm.jsp
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>QnA 수정</title>
 </head>
 
   <%

--- a/src/main/webapp/qaboard/qaUpdateForm.jsp
+++ b/src/main/webapp/qaboard/qaUpdateForm.jsp
@@ -20,7 +20,7 @@
    String currentPage = util.SecurityUtil.digitsOnly(request.getParameter("currentPage"));
    
    QaDao dao = new QaDao();
-   QaDto dto = dao.getDataQa(q_num);
+   QaDto dto = dao.selectDataQa(q_num);
    %>
 <body>
 


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상)의 게시판 네 번째 하위도메인 **qa(QnA 게시판)** 리팩터링. notice(#80)·event(#81)·review(#82)와 동일 방식·강도(full rigor)로 진행했다. **동작 보존(순수 리팩터링)**이 원칙이며 SQL·로직·시그니처는 보존했다.

대상: `qa/model/QaDao.java` + 뷰 `qaboard/`·`mypage/`. ※ `adminqnalist`·`deleteadminqna`는 qaanswer 도메인(QaanswerDao) 소관이라 미접촉.

## 커밋 (작은 단위 6개)
1. **QaDao 위생** — db 필드 private화, 죽은 import 2개(`notice.model.NoticeDto`·`review.model.ReviewDto`, 참조 0건) 제거, `// TODO Auto-generated catch block` 주석 9곳 제거(printStackTrace는 2단계 제외라 유지), 들여쓰기 탭/스페이스 혼용을 탭+K&R로 정규화(`git diff -w`로 토큰 변경 외 0건 확인).
2. **죽은 코드 제거** — `getAllQa()`(호출처 0건) 삭제 + `getList`의 죽은 `qa_cnt` 상관 서브쿼리·주석(`//dto.setQa_cnt(...)`) 제거. 서브쿼리 결과는 DTO에 적재되지 않아 소비처 0건(행마다 도는 서브쿼리만 낭비)이라 동작-중립.
3. **중복 메서드 통합** — `deleteQna(q_num)`와 `deleteQa(q_num)`가 SQL까지 완전 동일 → `deleteQa`로 일원화, 호출처 `deleteqna.jsp` 갱신. ⚠ qaanswer의 `deleteQna(q_num, qa_num)`(2-arg)·`deleteadminqna.jsp`는 미접촉.
4. **mapRow 추출** — `selectMyPageList`·`selectPagingList`·`selectDataQa`의 7컬럼 ResultSet→DTO 매핑 중복을 `private QaDto mapRow(ResultSet)`로 통합. 단일행 `selectDataQa`는 선례대로 `while` 유지.
5. **조회 get\*→select\* 통일** — `selectTotalCount`/`selectPagingList`/`selectDataQa`/`selectMyPageList`/`selectMyPageTotalCount`(camelCase, 시그니처 불변). 호출처 8곳 수신자 타입 기준 전수 갱신. ⚠ qaanswer 동명 메서드(0-arg·2-arg)·DTO snake_case 게터 미접촉.
6. **JSP 위생** — 이번에 만진 qa JSP 7곳의 `<title>Insert title here</title>` 잔재 교체. 미접촉 `qaAction`·`qaForm`은 보존.

## 보존
- `QaDto.qa_cnt` 멤버는 **살아있음**(`qaList.jsp`가 별도 계산해 출력) → 미접촉.
- 보안 가드(로그인·isPost·CSRF `checkCsrf`·소유자/관리자 권한 IDOR 방지)·출력 인코딩 약화 없음.

## 검증
- 매 커밋 `javac`(servlet-api 4.0.1 + WEB-INF/lib 클래스패스, `-encoding UTF-8`, src 전체) **EXIT=0**.
- 옛 이름 전수 grep: `getAllQa`·`getDataQa`·QaDao의 `getTotalCount`/`getList` **0건**, 잔존은 모두 qaanswer 도메인(의도적 미접촉).
- `/code-review`(high)·`/simplify`(4각도) 통과 — 버그 0건. (효율 각도가 지적한 `qaList.jsp` 답변수 N+1은 pre-existing이라 범위 외; 단순화 각도의 `selectDataQa` null 초기화 제안은 `qaDetail.jsp`가 null 미체크라 NPE 위험·동작 변경이라 의도적 보류.)

## ⚠ 런타임 스모크 테스트 필요 (Tomcat 검증 불가 환경)
QnA **목록 / 상세 / 작성 / 수정 / 삭제**, **내 문의 목록**, **조회수 증가**, **답변수(qa_cnt) 표시**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
