### PR TITLE
게시판QnA(qaanswer) 리팩터링 — 위생·죽은코드·중복통합·mapRow·get→select·누수수정

### DIFF
--- a/src/main/java/qaanswer/model/QaanswerDao.java
+++ b/src/main/java/qaanswer/model/QaanswerDao.java
@@ -54,15 +54,7 @@ public class QaanswerDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-				QaanswerDto dto = new QaanswerDto();
-
-				dto.setQ_num(rs.getString("q_num")); // 게시판 번호
-				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호
-				dto.setQa_myid(rs.getString("qa_myid"));
-				dto.setQa_content(rs.getString("qa_content")); // 댓글내용
-				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
-
-				list.add(dto);
+				list.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -90,13 +82,7 @@ public class QaanswerDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				dto.setQ_num(rs.getString("q_num")); // 게시판 번호
-				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호
-				dto.setQa_myid(rs.getString("qa_myid"));
-				dto.setQa_content(rs.getString("qa_content")); // 댓글내용
-				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
-
+				dto = mapRow(rs);
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -203,16 +189,7 @@ public class QaanswerDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				QaanswerDto dto = new QaanswerDto();
-
-				dto.setQ_num(rs.getString("q_num"));
-				dto.setQa_num(rs.getString("qa_num"));
-				dto.setQa_myid(rs.getString("qa_myid"));
-				dto.setQa_content(rs.getString("qa_content"));
-				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
-
-				mypagelist.add(dto);
+				mypagelist.add(mapRow(rs));
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
@@ -243,6 +220,19 @@ public class QaanswerDao {
 			e.printStackTrace();
 		}
 		return title;
+	}
+
+	// ResultSet 한 행을 QaanswerDto로 매핑(조회 메서드 공통)
+	private QaanswerDto mapRow(ResultSet rs) throws SQLException {
+		QaanswerDto dto = new QaanswerDto();
+
+		dto.setQ_num(rs.getString("q_num")); // 게시판 번호
+		dto.setQa_num(rs.getString("qa_num")); // 댓글 번호
+		dto.setQa_myid(rs.getString("qa_myid"));
+		dto.setQa_content(rs.getString("qa_content")); // 댓글내용
+		dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
+
+		return dto;
 	}
 
 }

--- a/src/main/java/qaanswer/model/QaanswerDao.java
+++ b/src/main/java/qaanswer/model/QaanswerDao.java
@@ -218,6 +218,8 @@ public class QaanswerDao {
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
 		return title;
 	}

--- a/src/main/java/qaanswer/model/QaanswerDao.java
+++ b/src/main/java/qaanswer/model/QaanswerDao.java
@@ -8,21 +8,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mysql.db.DbConnect;
-import qa.model.QaDto;
 
 public class QaanswerDao {
-	
-	DbConnect db = new DbConnect();
-	
+
+	private DbConnect db = new DbConnect();
+
 	//insert
 	public void insertQaAnswer(QaanswerDto dto) {
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 
-		//String sql = "insert into qaanswerboard (q_num,qa_content,qa_writeday) values(?,?,now())";
 		String sql = "INSERT INTO qaanswerboard (q_num, qa_num, qa_myid, qa_content, qa_writeday) "
-	            + "VALUES (?, (SELECT COALESCE(MAX(qa_num), 0) + 1 FROM "
-	            + "(SELECT qa_num FROM qaanswerboard WHERE q_num = ?) AS subquery), ?, ?, sysdate())";
+				+ "VALUES (?, (SELECT COALESCE(MAX(qa_num), 0) + 1 FROM "
+				+ "(SELECT qa_num FROM qaanswerboard WHERE q_num = ?) AS subquery), ?, ?, sysdate())";
 
 		try {
 			pstmt = conn.prepareStatement(sql);
@@ -34,13 +32,12 @@ public class QaanswerDao {
 
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
 		}
 	}
-	
+
 	// 댓글출력
 	public List<QaanswerDto> getQaAnswerList(String q_num) {
 		List<QaanswerDto> list = new ArrayList<QaanswerDto>();
@@ -60,15 +57,14 @@ public class QaanswerDao {
 				QaanswerDto dto = new QaanswerDto();
 
 				dto.setQ_num(rs.getString("q_num")); // 게시판 번호
-				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호 
+				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호
 				dto.setQa_myid(rs.getString("qa_myid"));
-				dto.setQa_content(rs.getString("qa_content")); // 댓글내용 
-				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));;
-				
+				dto.setQa_content(rs.getString("qa_content")); // 댓글내용
+				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
+
 				list.add(dto);
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -76,8 +72,6 @@ public class QaanswerDao {
 
 		return list;
 	}
-	
-	
 
 	// 수정시 나타낼 데이타
 	public QaanswerDto getAnswerData(String q_num, String qa_num) {
@@ -98,14 +92,13 @@ public class QaanswerDao {
 			while (rs.next()) {
 
 				dto.setQ_num(rs.getString("q_num")); // 게시판 번호
-				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호 
+				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호
 				dto.setQa_myid(rs.getString("qa_myid"));
-				dto.setQa_content(rs.getString("qa_content")); // 댓글내용 
+				dto.setQa_content(rs.getString("qa_content")); // 댓글내용
 				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
 
 			}
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(rs, pstmt, conn);
@@ -124,15 +117,12 @@ public class QaanswerDao {
 		try {
 			pstmt = conn.prepareStatement(sql);
 
-			
 			pstmt.setString(1, dto.getQa_content());
 			pstmt.setString(2, dto.getQ_num());
 			pstmt.setString(3, dto.getQa_num());
-			
 
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
@@ -154,160 +144,155 @@ public class QaanswerDao {
 
 			pstmt.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
 		}
 	}
-	
+
 	// 관리자페이지에 가져오는 관리자가 쓴 Q&A 메서드
-		public QaanswerDto getAdminAnswerData() {
-			QaanswerDto dto = new QaanswerDto();
+	public QaanswerDto getAdminAnswerData() {
+		QaanswerDto dto = new QaanswerDto();
 
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
 
-			String sql = "select * from qaanswerboard where qa_myid='admin'";
+		String sql = "select * from qaanswerboard where qa_myid='admin'";
 
-			try {
-				pstmt = conn.prepareStatement(sql);
-				rs = pstmt.executeQuery();
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
 
-				while (rs.next()) {
+			while (rs.next()) {
 
-					dto.setQ_num(rs.getString("q_num")); // 게시판 번호
-					dto.setQa_num(rs.getString("qa_num")); // 댓글 번호 
-					dto.setQa_myid(rs.getString("qa_myid"));
-					dto.setQa_content(rs.getString("qa_content")); // 댓글내용 
-					dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
+				dto.setQ_num(rs.getString("q_num")); // 게시판 번호
+				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호
+				dto.setQa_myid(rs.getString("qa_myid"));
+				dto.setQa_content(rs.getString("qa_content")); // 댓글내용
+				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
 
-				}
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(rs, pstmt, conn);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return dto;
+	}
+
+	// adminqnalist.jsp //페이징리스트/ 전체페이지수 반환하기
+	public int getMyPageTotalCount() {
+
+		int total = 0;
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from qaanswerboard where qa_myid='admin'";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			rs = pstmt.executeQuery();
+
+			if (rs.next()) {
+				total = rs.getInt(1);
 			}
 
-			return dto;
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
-		
-		// adminqnalist.jsp //페이징리스트/ 전체페이지수 반환하기
-		public int getMyPageTotalCount() {
-	      
-	    int total = 0;
-			
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-	  
-	    String sql = "select count(*) from qaanswerboard where qa_myid='admin'";
-			
-			try {
-				pstmt = conn.prepareStatement(sql);
-				rs = pstmt.executeQuery();
-				
-				if(rs.next()) {
-					total = rs.getInt(1);
-				}
-				
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}finally {
-				db.dbClose(rs, pstmt, conn);
+
+		return total;
+
+	}
+
+	// adminqalist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
+	public List<QaanswerDto> getmypagelist(int start, int perPage) {
+		List<QaanswerDto> mypagelist = new ArrayList<QaanswerDto>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select * from qaanswerboard where qa_myid='admin' order by q_num desc limit ?,?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+
+			pstmt.setInt(1, start);
+			pstmt.setInt(2, perPage);
+
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+
+				QaanswerDto dto = new QaanswerDto();
+
+				dto.setQ_num(rs.getString("q_num"));
+				dto.setQa_num(rs.getString("qa_num"));
+				dto.setQa_myid(rs.getString("qa_myid"));
+				dto.setQa_content(rs.getString("qa_content"));
+				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
+
+				mypagelist.add(dto);
 			}
-			
-			return total;
-			
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
-		
-		// adminqalist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-		public List<QaanswerDto> getmypagelist(int start, int perPage) {
-			List<QaanswerDto> mypagelist = new ArrayList<QaanswerDto>();
-	  
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-	  
-			String sql = "select * from qaanswerboard where qa_myid='admin' order by q_num desc limit ?,?";
+		return mypagelist;
+	}
 
-			try {
-				pstmt = conn.prepareStatement(sql);
-				
-				pstmt.setInt(1, start);
-				pstmt.setInt(2, perPage);
-	      
-	      rs = pstmt.executeQuery();
+	// adminpage에서 삭제하기
+	public void deleteQna(String q_num, String qa_num) {
 
-				while (rs.next()) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
 
-					QaanswerDto dto = new QaanswerDto();
+		String sql = "delete from qaanswerboard where q_num=? and qa_num=?";
 
-					dto.setQ_num(rs.getString("q_num"));
-					dto.setQa_num(rs.getString("qa_num"));
-					dto.setQa_myid(rs.getString("qa_myid"));
-					dto.setQa_content(rs.getString("qa_content"));
-					dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
-	        
-					mypagelist.add(dto);
-	      }
-	      } catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(rs, pstmt, conn);
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, q_num);
+			pstmt.setString(2, qa_num);
+
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+
+	}
+
+	//q_num을 통해 문의글 제목 가져오기
+	public String getTitle(String q_num) {
+		String title = "";
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select q_subject from qaboard where q_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, q_num);
+			rs = pstmt.executeQuery();
+
+			if (rs.next()) {
+				title = rs.getString("q_subject");
 			}
-	    return mypagelist;
+		} catch (SQLException e) {
+			e.printStackTrace();
 		}
-		// adminpage에서 삭제하기
-		public void deleteQna(String q_num,String qa_num) {
-
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-
-			String sql = "delete from qaanswerboard where q_num=? and qa_num=?";
-
-			try {
-				pstmt = conn.prepareStatement(sql);
-				pstmt.setString(1, q_num);
-				pstmt.setString(2, qa_num);
-
-				pstmt.execute();
-
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} finally {
-				db.dbClose(pstmt, conn);
-			}
-
-		}
-		//q_num을 통해 문의글 제목 가져오기
-		public String getTitle(String q_num) {
-			String title="";
-			Connection conn = db.getConnection();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			
-			String sql="select q_subject from qaboard where q_num=?";
-			
-			try {
-				pstmt=conn.prepareStatement(sql);
-				pstmt.setString(1, q_num);
-				rs=pstmt.executeQuery();
-				
-				if(rs.next()) {
-					title=rs.getString("q_subject");
-				}
-			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			return title;
-		}
-	
+		return title;
+	}
 
 }

--- a/src/main/java/qaanswer/model/QaanswerDao.java
+++ b/src/main/java/qaanswer/model/QaanswerDao.java
@@ -131,6 +131,11 @@ public class QaanswerDao {
 
 	// 삭제
 	public void deleteQaAnswer(QaanswerDto dto) {
+		deleteQaAnswer(dto.getQ_num(), dto.getQa_num());
+	}
+
+	// 삭제(q_num, qa_num 직접 지정 — 관리자 페이지 일괄 삭제 등)
+	public void deleteQaAnswer(String q_num, String qa_num) {
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 
@@ -139,8 +144,8 @@ public class QaanswerDao {
 		try {
 			pstmt = conn.prepareStatement(sql);
 
-			pstmt.setString(1, dto.getQ_num());
-			pstmt.setString(2, dto.getQa_num());
+			pstmt.setString(1, q_num);
+			pstmt.setString(2, qa_num);
 
 			pstmt.execute();
 		} catch (SQLException e) {
@@ -215,29 +220,6 @@ public class QaanswerDao {
 			db.dbClose(rs, pstmt, conn);
 		}
 		return mypagelist;
-	}
-
-	// adminpage에서 삭제하기
-	public void deleteQna(String q_num, String qa_num) {
-
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-
-		String sql = "delete from qaanswerboard where q_num=? and qa_num=?";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, q_num);
-			pstmt.setString(2, qa_num);
-
-			pstmt.execute();
-
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(pstmt, conn);
-		}
-
 	}
 
 	//q_num을 통해 문의글 제목 가져오기

--- a/src/main/java/qaanswer/model/QaanswerDao.java
+++ b/src/main/java/qaanswer/model/QaanswerDao.java
@@ -39,7 +39,7 @@ public class QaanswerDao {
 	}
 
 	// 댓글출력
-	public List<QaanswerDto> getQaAnswerList(String q_num) {
+	public List<QaanswerDto> selectQaAnswerList(String q_num) {
 		List<QaanswerDto> list = new ArrayList<QaanswerDto>();
 
 		Connection conn = db.getConnection();
@@ -66,7 +66,7 @@ public class QaanswerDao {
 	}
 
 	// 수정시 나타낼 데이타
-	public QaanswerDto getAnswerData(String q_num, String qa_num) {
+	public QaanswerDto selectAnswerData(String q_num, String qa_num) {
 		QaanswerDto dto = new QaanswerDto();
 
 		Connection conn = db.getConnection();
@@ -142,7 +142,7 @@ public class QaanswerDao {
 	}
 
 	// adminqnalist.jsp //페이징리스트/ 전체페이지수 반환하기
-	public int getMyPageTotalCount() {
+	public int selectMyPageTotalCount() {
 
 		int total = 0;
 
@@ -171,7 +171,7 @@ public class QaanswerDao {
 	}
 
 	// adminqalist.jsp //페이징리스트/paging list (한 페이지에서 첫번쨰랑 마지막번호 출력 하고 그 이상은 다음 페이지로 넘김)
-	public List<QaanswerDto> getmypagelist(int start, int perPage) {
+	public List<QaanswerDto> selectMyPageList(int start, int perPage) {
 		List<QaanswerDto> mypagelist = new ArrayList<QaanswerDto>();
 
 		Connection conn = db.getConnection();
@@ -200,7 +200,7 @@ public class QaanswerDao {
 	}
 
 	//q_num을 통해 문의글 제목 가져오기
-	public String getTitle(String q_num) {
+	public String selectTitle(String q_num) {
 		String title = "";
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;

--- a/src/main/java/qaanswer/model/QaanswerDao.java
+++ b/src/main/java/qaanswer/model/QaanswerDao.java
@@ -150,38 +150,6 @@ public class QaanswerDao {
 		}
 	}
 
-	// 관리자페이지에 가져오는 관리자가 쓴 Q&A 메서드
-	public QaanswerDto getAdminAnswerData() {
-		QaanswerDto dto = new QaanswerDto();
-
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-
-		String sql = "select * from qaanswerboard where qa_myid='admin'";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			rs = pstmt.executeQuery();
-
-			while (rs.next()) {
-
-				dto.setQ_num(rs.getString("q_num")); // 게시판 번호
-				dto.setQa_num(rs.getString("qa_num")); // 댓글 번호
-				dto.setQa_myid(rs.getString("qa_myid"));
-				dto.setQa_content(rs.getString("qa_content")); // 댓글내용
-				dto.setQa_writeday(rs.getTimestamp("qa_writeday"));
-
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-
-		return dto;
-	}
-
 	// adminqnalist.jsp //페이징리스트/ 전체페이지수 반환하기
 	public int getMyPageTotalCount() {
 

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -13,7 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>관리자 QnA 답변 목록</title>
 <style type="text/css">
 ul.tabs {
 	margin: 0px;

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -256,7 +256,7 @@ font-size: 14px;
 	QaanswerDao dao=new QaanswerDao();
 	
 	//전체갯수
-	int totalCount=dao.getMyPageTotalCount();
+	int totalCount=dao.selectMyPageTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
 	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
@@ -296,7 +296,7 @@ font-size: 14px;
 	no=totalCount-(currentPage-1)*perPage;
 	
 	//페이지에서 보여질 글만 가져오기
-	List<QaanswerDto> list = dao.getmypagelist(startNum, perPage);
+	List<QaanswerDto> list = dao.selectMyPageList(startNum, perPage);
 		
 	//해당 페이지에 게시물이 없을 경우 이전 페이지로 돌아가기
 	//마지막 페이지의 단 한개 남은 글을 삭제 시 빈페이지가 남는데 해결책으로 그 이전 페이지로 가는 로직 설정
@@ -361,7 +361,7 @@ font-size: 14px;
 			<%=no-- %>
 			</td>
 			<td>
-				<%=util.SecurityUtil.escapeHtml(dao.getTitle(dto.getQ_num()))%>
+				<%=util.SecurityUtil.escapeHtml(dao.selectTitle(dto.getQ_num()))%>
 			</td>
 		    <td>
 		    <a href="index.jsp?main=qaboard/qaDetail.jsp?currentPage=<%=currentPage %>&q_num=<%=dto.getQ_num() %>"><%=util.SecurityUtil.escapeHtml(dto.getQa_content())%></a>

--- a/src/main/webapp/mypage/deleteadminqna.jsp
+++ b/src/main/webapp/mypage/deleteadminqna.jsp
@@ -28,7 +28,7 @@
         String qNum = numArray[i]; // 짝수 인덱스는 q_num 값
         String qaNum = numArray[i + 1]; // 홀수 인덱스는 qa_num 값
         // Q_num과 qa_num에 해당하는 데이터 삭제
-        dao.deleteQna(qNum, qaNum);
+        dao.deleteQaAnswer(qNum, qaNum);
     }
     // 목록으로 이동
     response.sendRedirect("../index.jsp?main=mypage/adminqnalist.jsp");

--- a/src/main/webapp/mypage/deleteadminqna.jsp
+++ b/src/main/webapp/mypage/deleteadminqna.jsp
@@ -8,7 +8,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Dongle&family=Nanum+Pen+Script&family=Noto+Sans+KR:wght@100..900&family=Single+Day&family=Stylish&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>관리자 QnA 답변 삭제</title>
 </head>
 <body>
 <%

--- a/src/main/webapp/qaanswer/qaAnswerOneData.jsp
+++ b/src/main/webapp/qaanswer/qaAnswerOneData.jsp
@@ -8,7 +8,7 @@
     String q_num = request.getParameter("q_num");
     String qa_num = request.getParameter("qa_num");
     QaanswerDao dao = new QaanswerDao();
-    QaanswerDto dto = dao.getAnswerData(q_num, qa_num);
+    QaanswerDto dto = dao.selectAnswerData(q_num, qa_num);
     
     JSONObject ob = new JSONObject();
     ob.put("q_num", dto.getQ_num());

--- a/src/main/webapp/qaanswer/qaAnswerUpdateForm.jsp
+++ b/src/main/webapp/qaanswer/qaAnswerUpdateForm.jsp
@@ -8,7 +8,7 @@
    String qa_num = request.getParameter("qa_num");
    
    QaanswerDao qdao=new QaanswerDao();
-   QaanswerDto qdto=qdao.getAnswerData(q_num, qa_num);
+   QaanswerDto qdto=qdao.selectAnswerData(q_num, qa_num);
    
    JSONObject ob=new JSONObject();
    ob.put("q_num", qdto.getQ_num());

--- a/src/main/webapp/qaanswer/qaListAction.jsp
+++ b/src/main/webapp/qaanswer/qaListAction.jsp
@@ -10,7 +10,7 @@
 <%
   String q_num=request.getParameter("q_num");
   QaanswerDao dao=new QaanswerDao();
-  List<QaanswerDto> list=dao.getQaAnswerList(q_num);
+  List<QaanswerDto> list=dao.selectQaAnswerList(q_num);
   
   JSONArray arr=new JSONArray();
   SimpleDateFormat sdf=new SimpleDateFormat("yyyy-MM-dd HH:mm");

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -183,7 +183,7 @@
 	for(QaDto dto:list) {
 		
 		//댓글 변수에 댓글 총 갯수 넣기
-		int acount = qdao.getQaAnswerList(dto.getQ_num()).size();
+		int acount = qdao.selectQaAnswerList(dto.getQ_num()).size();
 		dto.setQa_cnt(acount);
 	}
       


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션 일관화 + 유지보수성 향상)의 게시판 마지막 하위도메인 **qaanswer(QnA 답변)** 리팩터링이다. 짝 도메인 qa(#83)와 동일 방식·강도(full rigor)로 진행했으며, 동작 보존을 원칙으로 작은 커밋 7개로 나눴다. **게시판 도메인(notice→event→review→qa→qaanswer)은 이 PR로 종료된다.**

대상: `qaanswer/model/QaanswerDao.java` + 호출 JSP 6개. `QaanswerDto`는 미접촉.

## 변경 내용 (커밋 순)
1. **위생 + 들여쓰기 정규화** — db 필드 private화, 죽은 import `qa.model.QaDto` 제거(사용처 0건), `// TODO Auto-generated catch block` 주석 전부 제거, 이중 세미콜론 `;;` 1곳 제거, insertQaAnswer 죽은 주석 SQL 줄 제거, 탭+K&R로 정규화(전체 재작성). `git diff -w` 토큰 0건.
2. **죽은 코드 제거** — `getAdminAnswerData()`(호출처 0건) 삭제.
3. **중복 메서드 통합** — `deleteQna(q_num, qa_num)`(2-arg)가 `deleteQaAnswer(dto)`와 SQL 완전 동일 → `deleteQaAnswer(String, String)` 오버로드 신설 + `deleteQaAnswer(dto)`는 위임, `deleteQna` 삭제 + `deleteadminqna.jsp` 호출처 갱신. (관리자 가드·isPost·CSRF 불변)
4. **mapRow 추출** — selectQaAnswerList·selectAnswerData·selectMyPageList의 5컬럼 매핑을 `private QaanswerDto mapRow(rs)`로 통합. 단일행 selectAnswerData는 선례대로 `while` 유지.
5. **조회 get*→select* 통일** — getQaAnswerList→selectQaAnswerList / getAnswerData→selectAnswerData / getMyPageTotalCount→selectMyPageTotalCount / getmypagelist→selectMyPageList / getTitle→selectTitle (시그니처 불변). 호출처 7곳/6파일 전수 갱신(**교차도메인** qaboard/qaList.jsp의 qdao 포함). DTO snake_case 게터 미접촉.
6. **만진 JSP 위생** — adminqnalist·deleteadminqna의 `<title>Insert title here</title>` 잔재 교체.
7. **자원 누수 수정(코드리뷰 발견)** — selectTitle만 finally 누락으로 JDBC 자원 미close. adminqnalist가 목록 렌더링 중 **행마다** 호출하므로 페이지당 perPage 커넥션 누수 → 풀 고갈 위험. 파일 내 타 메서드와 동일하게 `finally { db.dbClose(rs, pstmt, conn) }` 추가. (기존 결함이나 만진 메서드라 정정)

## 보안 보존
- 쓰기/삭제 액션(qaAnswerInsert/Update/Delete, deleteadminqna)의 로그인·isPost·CSRF·관리자 권한 가드 불변.
- `qaListAction.jsp`의 JSON `escapeHtml`(DOM XSS 방어)·`adminqnalist` escapeHtml 출력 인코딩 약화 없음.

## 검증
- 매 커밋 javac 컴파일 EXIT=0 (servlet-api 4.0.1 + WEB-INF/lib jar, `-encoding UTF-8`, src/main/java 전체).
- 전수 grep: 옛 메서드명(getQaAnswerList/getAnswerData/getAdminAnswerData/getMyPageTotalCount/getmypagelist/.getTitle(/.deleteQna() 코드 잔존 0건.
- `/simplify`(4각도)·`/code-review`(high) 실행 → selectTitle 누수 1건 발견·수정, 그 외 findings 0.

## ⚠ JSP 런타임 스모크 테스트 필요 (javac로 검증 불가)
Tomcat 기동 후 아래 흐름 수동 확인 권장:
- QnA **답변 작성** / **목록(AJAX)** / **수정** / **삭제**
- 관리자 **답변 목록(adminqnalist) 페이징**
- 관리자 목록의 **문의 제목 표시(selectTitle)**
- 관리자 **답변 일괄 삭제(deleteadminqna)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
