### PR TITLE
쇼핑(shop) 도메인 리팩터링 — 패키지 표준화·자원 누수 수정·조회 select* 통일

### DIFF
--- a/src/main/java/shop/model/ShopDao.java
+++ b/src/main/java/shop/model/ShopDao.java
@@ -1,6 +1,5 @@
 package shop.model;
 
-import java.nio.channels.SelectableChannel;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -9,12 +8,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mysql.db.DbConnect;
-import review.model.ReviewDto;
 
 public class ShopDao {
-	
-	DbConnect db = new DbConnect();
-	
+
+	private DbConnect db = new DbConnect();
+
 	//insert
 	public void insertShop(ShopDto dto) {
 
@@ -33,50 +31,48 @@ public class ShopDao {
 			pstmt.execute();
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
 		}
 
 	}
-	
+
 	//전체 list 출력
 	public List<ShopDto> allShop() {
-		
+
 		List<ShopDto> list = new ArrayList<ShopDto>();
-		
+
 		Connection conn = db.getConnection();
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-		
+
 		String sql = "Select * from shop order by s_num desc";
-		
+
 		try {
 			pstmt = conn.prepareStatement(sql);
 			rs = pstmt.executeQuery();
-			
+
 			while(rs.next()) {
 				ShopDto dto = new ShopDto();
-				
+
 				dto.setS_num(rs.getString("s_num"));
 				dto.setS_category(rs.getString("s_category"));
 				dto.setS_site(rs.getString("s_site"));
 				dto.setS_image(rs.getString("s_image"));
-				
+
 				list.add(dto);
-				
+
 			}
-			
+
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		
+
 		return list;
-		
+
 	}
-	
+
 	//삭제
 	public void deleteShop(String s_num) {
 
@@ -92,49 +88,45 @@ public class ShopDao {
 			pstmt.execute();
 
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			db.dbClose(pstmt, conn);
 		}
 
 	}
-	
-	
+
 	//num값 넘겨주기 -> dto 반환!!
-			public ShopDto getDataShop(String s_num) {
-				ShopDto dto = new ShopDto();
+	public ShopDto getDataShop(String s_num) {
+		ShopDto dto = new ShopDto();
 
-				Connection conn = db.getConnection();
-				PreparedStatement pstmt = null;
-				ResultSet rs = null;
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
 
-				String sql = "select * from shop where s_num=?";
+		String sql = "select * from shop where s_num=?";
 
-				try {
-					pstmt = conn.prepareStatement(sql);
+		try {
+			pstmt = conn.prepareStatement(sql);
 
-					pstmt.setString(1, s_num);
-					rs = pstmt.executeQuery();
+			pstmt.setString(1, s_num);
+			rs = pstmt.executeQuery();
 
-					while (rs.next()) {
+			while (rs.next()) {
 
+				dto.setS_num(rs.getString("s_num"));
+				dto.setS_category(rs.getString("s_category"));
+				dto.setS_site(rs.getString("s_site"));
+				dto.setS_image(rs.getString("s_image"));
 
-						dto.setS_num(rs.getString("s_num"));
-						dto.setS_category(rs.getString("s_category"));
-						dto.setS_site(rs.getString("s_site"));
-						dto.setS_image(rs.getString("s_image"));
-
-					}
-
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				} finally {
-					db.dbClose(rs, pstmt, conn);
-				}
-
-				return dto;
 			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return dto;
+	}
 
 }

--- a/src/main/java/shop/model/ShopDao.java
+++ b/src/main/java/shop/model/ShopDao.java
@@ -67,6 +67,8 @@ public class ShopDao {
 
 		} catch (SQLException e) {
 			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
 		}
 
 		return list;

--- a/src/main/java/shop/model/ShopDao.java
+++ b/src/main/java/shop/model/ShopDao.java
@@ -1,4 +1,4 @@
-package shop;
+package shop.model;
 
 import java.nio.channels.SelectableChannel;
 import java.sql.Connection;

--- a/src/main/java/shop/model/ShopDao.java
+++ b/src/main/java/shop/model/ShopDao.java
@@ -39,7 +39,7 @@ public class ShopDao {
 	}
 
 	//전체 list 출력
-	public List<ShopDto> allShop() {
+	public List<ShopDto> selectAllShop() {
 
 		List<ShopDto> list = new ArrayList<ShopDto>();
 
@@ -90,7 +90,7 @@ public class ShopDao {
 	}
 
 	//num값 넘겨주기 -> dto 반환!!
-	public ShopDto getDataShop(String s_num) {
+	public ShopDto selectDataShop(String s_num) {
 		ShopDto dto = new ShopDto();
 
 		Connection conn = db.getConnection();

--- a/src/main/java/shop/model/ShopDao.java
+++ b/src/main/java/shop/model/ShopDao.java
@@ -54,15 +54,7 @@ public class ShopDao {
 			rs = pstmt.executeQuery();
 
 			while(rs.next()) {
-				ShopDto dto = new ShopDto();
-
-				dto.setS_num(rs.getString("s_num"));
-				dto.setS_category(rs.getString("s_category"));
-				dto.setS_site(rs.getString("s_site"));
-				dto.setS_image(rs.getString("s_image"));
-
-				list.add(dto);
-
+				list.add(mapRow(rs));
 			}
 
 		} catch (SQLException e) {
@@ -114,12 +106,7 @@ public class ShopDao {
 			rs = pstmt.executeQuery();
 
 			while (rs.next()) {
-
-				dto.setS_num(rs.getString("s_num"));
-				dto.setS_category(rs.getString("s_category"));
-				dto.setS_site(rs.getString("s_site"));
-				dto.setS_image(rs.getString("s_image"));
-
+				dto = mapRow(rs);
 			}
 
 		} catch (SQLException e) {
@@ -127,6 +114,18 @@ public class ShopDao {
 		} finally {
 			db.dbClose(rs, pstmt, conn);
 		}
+
+		return dto;
+	}
+
+	//ResultSet → ShopDto 매핑(조회 메서드 공통)
+	private ShopDto mapRow(ResultSet rs) throws SQLException {
+		ShopDto dto = new ShopDto();
+
+		dto.setS_num(rs.getString("s_num"));
+		dto.setS_category(rs.getString("s_category"));
+		dto.setS_site(rs.getString("s_site"));
+		dto.setS_image(rs.getString("s_image"));
 
 		return dto;
 	}

--- a/src/main/java/shop/model/ShopDto.java
+++ b/src/main/java/shop/model/ShopDto.java
@@ -1,4 +1,4 @@
-package shop;
+package shop.model;
 
 public class ShopDto {
 	

--- a/src/main/webapp/shop/shopAction.jsp
+++ b/src/main/webapp/shop/shopAction.jsp
@@ -1,7 +1,7 @@
 <%@page import="util.AppConfig"%>
 <%@page import="util.SecurityUtil"%>
-<%@page import="shop.ShopDto"%>
-<%@page import="shop.ShopDao"%>
+<%@page import="shop.model.ShopDto"%>
+<%@page import="shop.model.ShopDao"%>
 <%@page import="com.oreilly.servlet.multipart.DefaultFileRenamePolicy"%>
 <%@page import="com.oreilly.servlet.MultipartRequest"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"

--- a/src/main/webapp/shop/shopAction.jsp
+++ b/src/main/webapp/shop/shopAction.jsp
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>상품 등록 처리</title>
 </head>
 <body>
 

--- a/src/main/webapp/shop/shopAllDelete.jsp
+++ b/src/main/webapp/shop/shopAllDelete.jsp
@@ -1,4 +1,4 @@
-<%@page import="shop.ShopDao"%>
+<%@page import="shop.model.ShopDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <!DOCTYPE html>

--- a/src/main/webapp/shop/shopAllDelete.jsp
+++ b/src/main/webapp/shop/shopAllDelete.jsp
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>상품 일괄 삭제</title>
 </head>
 <body>
 <%

--- a/src/main/webapp/shop/shopDelete.jsp
+++ b/src/main/webapp/shop/shopDelete.jsp
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>상품 삭제</title>
 </head>
 <body>
    <%

--- a/src/main/webapp/shop/shopDelete.jsp
+++ b/src/main/webapp/shop/shopDelete.jsp
@@ -26,7 +26,7 @@
     
     //db로 부터 저장된 이미지명 얻기
     ShopDao dao = new ShopDao();
-    String r_image = dao.getDataShop(s_num).getS_image();
+    String r_image = dao.selectDataShop(s_num).getS_image();
     
     //db삭제
     dao.deleteShop(s_num);

--- a/src/main/webapp/shop/shopDelete.jsp
+++ b/src/main/webapp/shop/shopDelete.jsp
@@ -1,5 +1,5 @@
 <%@page import="java.io.File"%>
-<%@page import="shop.ShopDao"%>
+<%@page import="shop.model.ShopDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <!DOCTYPE html>

--- a/src/main/webapp/shop/shopList.jsp
+++ b/src/main/webapp/shop/shopList.jsp
@@ -165,7 +165,7 @@ $(function(){
  String myid=(String)session.getAttribute("myid");
  
  ShopDao dao = new ShopDao();
- List<ShopDto> list = dao.allShop();
+ List<ShopDto> list = dao.selectAllShop();
  
  %>
 <body>

--- a/src/main/webapp/shop/shopList.jsp
+++ b/src/main/webapp/shop/shopList.jsp
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
-<title>Insert title here</title>
+<title>쇼핑몰</title>
 <style type="text/css">
   .s_list {
   width: 100%;

--- a/src/main/webapp/shop/shopList.jsp
+++ b/src/main/webapp/shop/shopList.jsp
@@ -1,6 +1,6 @@
-<%@page import="shop.ShopDto"%>
+<%@page import="shop.model.ShopDto"%>
 <%@page import="java.util.List"%>
-<%@page import="shop.ShopDao"%>
+<%@page import="shop.model.ShopDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <!DOCTYPE html>


### PR DESCRIPTION
## 개요

2단계(코드 컨벤션 일관화 + 유지보수성 향상) 리팩터링의 **쇼핑(shop)** 도메인. 게시판 5개(notice/event/review/qa/qaanswer)에 이어 동일 규칙·강도(full rigor)로 진행. 동작 보존이 원칙.

shop은 게시판과 달리 **패키지가 비표준**(`shop/` 직속)이고 **파일 업로드 도메인**이라 고유 차이가 많아 아래를 반영했다.

## 커밋 단위(6개, 매 단계 javac EXIT=0)

1. **패키지 표준화** `shop` → `shop/model/` — 다른 도메인과 동일한 `<도메인>/model/` 구조로 이동(git mv 2파일 + `package` 선언 2곳 + JSP `import` 6줄/4파일 갱신). `git grep`으로 옛 참조 0건 확인. (foodcart #79 선례)
2. **ShopDao 위생** — `db` 필드 private화 / 미사용 import 2개 제거(`java.nio.channels.SelectableChannel`, `review.model.ReviewDto`) / `// TODO Auto-generated catch block` 주석 제거(printStackTrace는 유지) / 들여쓰기 정규화. `git diff -w`로 의도한 토큰 변경 외 0건.
3. **allShop 자원 누수 수정** — `finally` 누락으로 ResultSet·PreparedStatement·Connection이 미close되던 것을 `finally { db.dbClose(rs, pstmt, conn) }` 추가로 정정(shopList가 페이지마다 호출 → 풀 누수 위험). qaanswer `selectTitle` 누수와 동형.
4. **mapRow 추출** — `selectAllShop`·`selectDataShop`의 4컬럼(s_num/s_category/s_site/s_image) 매핑을 `private ShopDto mapRow(ResultSet rs)`로 통합. 단일행 `selectDataShop`은 선례대로 `while` 유지.
5. **조회 select\* 통일** — `allShop`→`selectAllShop`, `getDataShop`→`selectDataShop`(시그니처 불변) + 호출처 갱신(shopList.jsp, shopDelete.jsp). `insertShop`·`deleteShop`은 이미 표준. DTO snake_case 게터 미변경.
6. **JSP 위생** — 만진 JSP 4곳의 `<title>Insert title here</title>` 잔재 교체(쇼핑몰 / 상품 등록 처리 / 상품 삭제 / 상품 일괄 삭제). 미접촉 shopForm.jsp는 선례대로 잔재 보존.

## 보안 보존(변경 없음)

- shopAction: isAdmin + isPost + 멀티파트 CSRF(`multi.getParameter("_csrf")`) + `validateOrDelete`(확장자+MIME) + `AppConfig.getUploadPath("shop")`(웹루트 외부) 전부 유지.
- shopDelete / shopAllDelete: isAdmin + isPost + checkCsrf 유지.
- shopList: `safeUrl(s_site)`·`urlEncode(s_image)` 출력 인코딩 유지.

## 범위 외(이번 PR 미수정)

- **shopDelete 파일경로 정합성 버그(pre-existing)**: `shopDelete.jsp`의 파일 삭제가 `getServletContext().getRealPath("/shopsave")`(옛 웹루트 내부 경로)를 쓰는데, 업로드는 `AppConfig.getUploadPath("shop")`(웹루트 외부)에 저장된다 → 경로 불일치로 실제 파일이 안 지워지고, redirect가 `if(file.exists())` 블록 안이라 파일을 못 찾으면 리다이렉트도 누락된다. **동작 변경 + 런타임 검증이 필요해 순수 컨벤션 범위를 넘으므로 이번 PR에서 제외**(보안/유지보수 백로그로 기록). 별도 PR에서 외부 경로 정합 + redirect 위치 수정 권장.
- shopDelete(개별: DB+파일삭제) vs shopAllDelete(일괄: DB만)은 용도가 달라 통합하지 않음(deleteShop SQL만 공유).
- shopList의 `"ADMIN".equals(role)` 직접비교 7곳은 role 기반이라 보안 OK, 반복 효익 낮아 미접촉.

## 검증

- 각 커밋 단계 javac EXIT=0(servlet-api 4.0.1 + WEB-INF/lib jar, -encoding UTF-8, src/main/java 전체).
- `git grep`으로 옛 참조(`allShop`/`getDataShop`/`shop.ShopDao`/`import shop.`/`package shop;`) 코드상 0건.
- /simplify(reuse·simplification·efficiency·altitude 4각도) + /code-review(high, 3 correctness 각도) 실행 — 버그 0건.

## ⚠ 런타임 스모크 테스트 필요(Tomcat)

JSP는 javac로 검증 불가하므로 Tomcat 기동 후 아래 수동 확인 필요:
- 상품 등록(이미지 업로드)
- 목록 3탭 이미지 표시(fileview)
- 개별 삭제(+파일)
- 일괄 삭제
- 패키지 이동 후 전 화면 로딩(ClassNotFoundException 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
