### PR TITLE
리팩터(즐겨찾기): FavoriteDao 신설로 분산 로직 응집

### DIFF
--- a/src/main/java/favorite/model/FavoriteDao.java
+++ b/src/main/java/favorite/model/FavoriteDao.java
@@ -1,0 +1,59 @@
+package favorite.model;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import mysql.db.DbConnect;
+
+// 즐겨찾기 도메인 DAO (기존 HugesoInfoDao·MemInfoDao에 분산돼 있던 즐겨찾기 로직을 응집)
+public class FavoriteDao {
+
+	private DbConnect db = new DbConnect();
+
+	// 휴게소 즐겨찾기 등록 (hugesodetail.jsp)
+	public void insertFavorite(FavoriteDto dto) {
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+
+		String sql="insert into favorite values(null,?,?)";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+
+			pstmt.setString(1, dto.getM_num());
+			pstmt.setString(2, dto.getH_num());
+
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+
+	// 휴게소 즐겨찾기 해제 (hugesodetail.jsp 하트 토글)
+	// 유지))f_num을 구해도 바로 반영이 되지 않아서 결국 m_num과 h_num이 일치할때 삭제되게끔 수정함
+	public void deleteFavorite(String m_num,String h_num) {
+		Connection conn=db.getConnection();
+		PreparedStatement pstmt=null;
+
+		String sql="delete from favorite where m_num=? and h_num=?";
+
+		try {
+			pstmt=conn.prepareStatement(sql);
+			pstmt.setString(1, m_num);
+			pstmt.setString(2, h_num);
+			pstmt.execute();
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
+}

--- a/src/main/java/favorite/model/FavoriteDao.java
+++ b/src/main/java/favorite/model/FavoriteDao.java
@@ -56,4 +56,86 @@ public class FavoriteDao {
 			db.dbClose(pstmt, conn);
 		}
 	}
+
+	// 유지)즐겨찾기 목록 출력 (mypage/favlist.jsp)
+	public List<HashMap<String, String>> selectFavlist(String m_id) {
+		List<HashMap<String, String>> list = new ArrayList<HashMap<String, String>>();
+
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select f.f_num,h.h_name,h.h_addr,h.h_pyeon, h.h_num,h.h_hp from hugesoinfo h,favorite f,meminfo m where h.h_num=f.h_num and m.m_num=f.m_num and m.m_id=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, m_id);
+			rs = pstmt.executeQuery();
+
+			while (rs.next()) {
+				HashMap<String, String> map = new HashMap<String, String>();
+				map.put("h_num", rs.getString("h_num"));
+				map.put("f_num", rs.getString("f_num"));
+				map.put("h_name", rs.getString("h_name"));
+				map.put("h_addr", rs.getString("h_addr"));
+				map.put("h_pyeon", rs.getString("h_pyeon"));
+				map.put("h_hp", rs.getString("h_hp"));
+
+				list.add(map);
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+		return list;
+	}
+
+	// 유지))즐겨찾기한 휴게소인지 여부 판단하는 거 (count 반환)
+	public int isFavorite(String m_num, String h_num) {
+		int fav = 0;
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+
+		String sql = "select count(*) from favorite where m_num=? and h_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, m_num);
+			pstmt.setString(2, h_num);
+			rs = pstmt.executeQuery();
+			if (rs.next()) {
+				fav = rs.getInt(1);
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(rs, pstmt, conn);
+		}
+
+		return fav;
+	}
+
+	// 소유자 범위 즐겨찾기 삭제 (IDOR 방어: 세션 m_num 소유분만 삭제 / mypage/favdelete.jsp)
+	// 주의) 소유자 조건 없는 PK-only 삭제는 IDOR 위험으로 두지 않는다.
+	//       즐겨찾기 목록 삭제는 반드시 아래 2-인자(f_num, m_num) 메서드만 사용한다.
+	public void deleteFavoriteByOwner(String f_num, String m_num) {
+		Connection conn = db.getConnection();
+		PreparedStatement pstmt = null;
+
+		String sql = "delete from favorite where f_num=? and m_num=?";
+
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, f_num);
+			pstmt.setString(2, m_num);
+			pstmt.execute();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			db.dbClose(pstmt, conn);
+		}
+	}
 }

--- a/src/main/java/hugesoinfo/model/HugesoInfoDao.java
+++ b/src/main/java/hugesoinfo/model/HugesoInfoDao.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import favorite.model.FavoriteDto;
 import mysql.db.DbConnect;
 
 
@@ -144,48 +143,6 @@ public class HugesoInfoDao {
 		}
 
 		return dto;
-	}
-
-	//휴게소 즐겨찾기 (hugesodetail.jsp)
-	public void insertFavorite(FavoriteDto dto) {
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-
-		String sql="insert into favorite values(null,?,?)";
-
-		try {
-			pstmt=conn.prepareStatement(sql);
-
-			pstmt.setString(1, dto.getM_num());
-			pstmt.setString(2, dto.getH_num());
-
-			pstmt.execute();
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(pstmt, conn);
-		}
-	}
-
-	//휴게소 즐겨찾기 해제 (hugesodetail.jsp)
-	//유지))f_num을 구해도 바로 반영이 되지 않아서 결국 m_num과 h_num이 일치할때 삭제되게끔 수정함
-	public void deleteFavorite(String m_num,String h_num) {
-		Connection conn=db.getConnection();
-		PreparedStatement pstmt=null;
-
-		String sql="delete from favorite where m_num=? and h_num=?";
-
-		try {
-			pstmt=conn.prepareStatement(sql);
-			pstmt.setString(1, m_num);
-			pstmt.setString(2, h_num);
-			pstmt.execute();
-
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(pstmt, conn);
-		}
 	}
 
 	public List<HugesoInfoDto> searchHugesoinfo(String h_name){

--- a/src/main/java/meminfo/model/MemInfoDao.java
+++ b/src/main/java/meminfo/model/MemInfoDao.java
@@ -5,7 +5,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import mysql.db.DbConnect;
@@ -412,67 +411,6 @@ public class MemInfoDao {
 		}
 	}
 
-	// 유지)즐겨찾기 목록 출력
-	public List<HashMap<String, String>> getFavlist(String m_id) {
-		List<HashMap<String, String>> list = new ArrayList<HashMap<String, String>>();
-
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-
-		String sql = "select f.f_num,h.h_name,h.h_addr,h.h_pyeon, h.h_num,h.h_hp from hugesoinfo h,favorite f,meminfo m where h.h_num=f.h_num and m.m_num=f.m_num and m.m_id=?";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, m_id);
-			rs = pstmt.executeQuery();
-
-			while (rs.next()) {
-				HashMap<String, String> map = new HashMap<String, String>();
-				map.put("h_num", rs.getString("h_num"));
-				map.put("f_num", rs.getString("f_num"));
-				map.put("h_name", rs.getString("h_name"));
-				map.put("h_addr", rs.getString("h_addr"));
-				map.put("h_pyeon", rs.getString("h_pyeon"));
-				map.put("h_hp", rs.getString("h_hp"));
-
-				list.add(map);
-			}
-
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-		return list;
-	}
-
-	// 유지))즐겨찾기한 휴게소인지 여부 판단하는 거
-	public int isFavorite(String m_num, String h_num) {
-		int fav = 0;
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-
-		String sql = "select count(*) from favorite where m_num=? and h_num=?";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, m_num);
-			pstmt.setString(2, h_num);
-			rs = pstmt.executeQuery();
-			if (rs.next()) {
-				fav = rs.getInt(1);
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(rs, pstmt, conn);
-		}
-
-		return fav;
-	}
-
 	// 아이디로 닉네임 조회 (리뷰 등에 연동)
 	public String selectNickById(String m_id) {
 		String m_nick = "";
@@ -549,24 +487,4 @@ public class MemInfoDao {
 		return list;
 	}
 
-	// 소유자 범위 즐겨찾기 삭제 (IDOR 방어: 세션 m_num 소유분만 삭제)
-	// 주의) 소유자 조건 없는 PK-only favDelete(String) 오버로드는 IDOR 위험으로 제거함.
-	//       즐겨찾기 삭제는 반드시 아래 2-인자(f_num, m_num) 메서드만 사용한다.
-	public void favDelete(String f_num, String m_num) {
-		Connection conn = db.getConnection();
-		PreparedStatement pstmt = null;
-
-		String sql = "delete from favorite where f_num=? and m_num=?";
-
-		try {
-			pstmt = conn.prepareStatement(sql);
-			pstmt.setString(1, f_num);
-			pstmt.setString(2, m_num);
-			pstmt.execute();
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			db.dbClose(pstmt, conn);
-		}
-	}
 }

--- a/src/main/webapp/hugesoinfo/checkfavorite.jsp
+++ b/src/main/webapp/hugesoinfo/checkfavorite.jsp
@@ -1,5 +1,6 @@
 <%@page import="org.json.simple.JSONObject"%>
 <%@page import="meminfo.model.MemInfoDao"%>
+<%@page import="favorite.model.FavoriteDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 
@@ -13,7 +14,7 @@ MemInfoDao dao=new MemInfoDao();
 String m_num=dao.selectM_num(util.SecurityUtil.currentId(session));
 String h_num=request.getParameter("h_num");
 
-int fav=dao.isFavorite(m_num, h_num);
+int fav=new FavoriteDao().isFavorite(m_num, h_num);
 JSONObject ob=new JSONObject();
 ob.put("fav", fav);
 out.print(ob.toString());

--- a/src/main/webapp/hugesoinfo/deletefavorite.jsp
+++ b/src/main/webapp/hugesoinfo/deletefavorite.jsp
@@ -1,4 +1,4 @@
-<%@page import="hugesoinfo.model.HugesoInfoDao"%>
+<%@page import="favorite.model.FavoriteDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
@@ -11,6 +11,6 @@
 		//유지))삭제메서드 수정
     String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 		String h_num=request.getParameter("h_num");
-    HugesoInfoDao dao=new HugesoInfoDao();
+    FavoriteDao dao=new FavoriteDao();
     dao.deleteFavorite(m_num, h_num);
 %>

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -9,7 +9,6 @@
 <%@page import="java.util.List"%>
 <%@page import="favorite.model.FavoriteDao"%>
 <%@page import="meminfo.model.MemInfoDao"%>
-<%@page import="meminfo.model.MemInfoDto"%>
 <%@page import="hugesoinfo.model.HugesoInfoDto"%>
 <%@page import="hugesoinfo.model.HugesoInfoDao"%>
 <%@page import="java.text.SimpleDateFormat"%>

--- a/src/main/webapp/hugesoinfo/hugesodetail.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodetail.jsp
@@ -7,7 +7,7 @@
 <%@page import="grade.model.GradeDto"%>
 <%@page import="grade.model.GradeDao"%>
 <%@page import="java.util.List"%>
-<%@page import="favorite.model.FavoriteDto"%>
+<%@page import="favorite.model.FavoriteDao"%>
 <%@page import="meminfo.model.MemInfoDao"%>
 <%@page import="meminfo.model.MemInfoDto"%>
 <%@page import="hugesoinfo.model.HugesoInfoDto"%>
@@ -48,7 +48,7 @@
 	
 	SimpleDateFormat sdf=new SimpleDateFormat("yy.MM.dd");
 
-	int fav=mdao.isFavorite(m_num, h_num);
+	int fav=new FavoriteDao().isFavorite(m_num, h_num);
 	
 	GradeDao gdao = new GradeDao();
 	GradeDto gdto = gdao.selectBestContent(h_num);

--- a/src/main/webapp/hugesoinfo/insertfavorite.jsp
+++ b/src/main/webapp/hugesoinfo/insertfavorite.jsp
@@ -1,5 +1,5 @@
 <%@page import="favorite.model.FavoriteDto"%>
-<%@page import="hugesoinfo.model.HugesoInfoDao"%>
+<%@page import="favorite.model.FavoriteDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
@@ -14,7 +14,7 @@
    String h_num=request.getParameter("h_num");
    String m_num=new meminfo.model.MemInfoDao().selectM_num(util.SecurityUtil.currentId(session));
 
-   HugesoInfoDao dao=new HugesoInfoDao();
+   FavoriteDao dao=new FavoriteDao();
    FavoriteDto dto=new FavoriteDto();
    
    dto.setH_num(h_num);

--- a/src/main/webapp/mypage/favdelete.jsp
+++ b/src/main/webapp/mypage/favdelete.jsp
@@ -1,4 +1,5 @@
 <%@page import="meminfo.model.MemInfoDao"%>
+<%@page import="favorite.model.FavoriteDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%
@@ -12,5 +13,5 @@ String f_num=util.SecurityUtil.digitsOnly(request.getParameter("f_num"));
 MemInfoDao dao=new MemInfoDao();
 // IDOR 방어: m_num을 세션 사용자로부터 도출해 본인 소유분만 삭제
 String m_num=dao.selectM_num(util.SecurityUtil.currentId(session));
-dao.favDelete(f_num, m_num);
+new FavoriteDao().deleteFavoriteByOwner(f_num, m_num);
 %>

--- a/src/main/webapp/mypage/favlist.jsp
+++ b/src/main/webapp/mypage/favlist.jsp
@@ -1,6 +1,6 @@
 <%@page import="java.util.List"%>
 <%@page import="java.util.HashMap"%>
-<%@page import="meminfo.model.MemInfoDao"%>
+<%@page import="favorite.model.FavoriteDao"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <!DOCTYPE html>
@@ -108,8 +108,8 @@
 
 <%
 String m_id=(String)session.getAttribute("myid");
-MemInfoDao dao=new MemInfoDao();
-List<HashMap<String,String>> list=dao.getFavlist(m_id);
+FavoriteDao dao=new FavoriteDao();
+List<HashMap<String,String>> list=dao.selectFavlist(m_id);
 %>
 <div style="margin: 0 auto; width: 65%;height:50%; padding: 20px 20px 20px 20px; margin-top: 50px;">
 	<%--<h3><b>휴게소 즐겨찾기 목록</b></h3> --%>


### PR DESCRIPTION
## 배경
즐겨찾기(favorite)는 지금까지의 어떤 도메인과도 다르게 **DTO만 있고 DAO가 없으며**, 즐겨찾기 DB 로직 5개가 두 DAO(`HugesoInfoDao`·`MemInfoDao`)에 **분산**된 비표준 구조였다. 2단계 컨벤션 일관화의 일환으로 **`favorite/model/FavoriteDao.java`를 신설**해 5개 메서드를 응집, favorite가 비로소 표준 `<도메인>/model/Dao` 구조를 갖추게 했다. **순수 리팩터(동작 보존)** — SQL·시그니처·로직은 그대로 옮겼다.

## 변경 내용 (커밋 3개)
1. **FavoriteDao 신설 + HugesoInfoDao 측 2개 이관** — `insertFavorite`·`deleteFavorite`(하트 토글)를 FavoriteDao로 이동. HugesoInfoDao에서 제거 + 죽은 `import favorite.model.FavoriteDto` 제거. 호출처 insertfavorite·deletefavorite.jsp 갱신.
2. **MemInfoDao 측 3개 이관(개명 2건)** — `isFavorite`·`getFavlist→selectFavlist`(조회는 select* 통일)·`favDelete→deleteFavoriteByOwner`를 FavoriteDao로. MemInfoDao 죽은 `import java.util.HashMap` 제거. 호출처 checkfavorite·hugesodetail·favdelete·favlist.jsp 갱신.
3. **hugesodetail.jsp 죽은 import 제거** — 사용처 0건이던 `import meminfo.model.MemInfoDto` 제거(/simplify 발견).

### 개명 사유
- `getFavlist → selectFavlist`: 조회 메서드는 `select*` 접두어 통일(DTO getter와 혼동 방지).
- `favDelete → deleteFavoriteByOwner`: `deleteFavorite(m_num,h_num)`와 시그니처가 **둘 다 (String,String)으로 동일**해 오버로드 불가 → 이름 구분 필수. delete* 접두어 컨벤션 부합 + **IDOR 소유자검증(f_num+m_num) 의미 보존**.

## 보안 보존 (불변)
- insert/delete/favdelete: `isLogin`+`isPost`+`checkCsrf`+세션 m_num 강제(클라이언트 m_num 불신, IDOR 방어) 전부 보존.
- `deleteFavoriteByOwner`는 `WHERE f_num=? AND m_num=?` 2-인자 소유자 범위 삭제 유지(PK-only 삭제로 되돌리지 않음).
- favdelete `digitsOnly(f_num)`, checkfavorite 세션 m_num, favlist `escapeHtml` 출력 보존.

## 검증
- **javac 정적검증 EXIT=0**(매 커밋, servlet-api 4.0.1 + WEB-INF/lib, -encoding UTF-8, src/main/java 전체).
- **전수 grep**: 옛 호출(`.getFavlist`/`.favDelete`/옛 수신자) 0건, 6개 호출처 전부 `favorite.model.FavoriteDao` import, 7번째 호출처 없음(title.jsp는 nav 링크).
- **/simplify**(reuse·simplification·efficiency·altitude 4각도): 죽은 import 1건 발견·수정, 그 외 0건.
- **/code-review(high)**(line-scan·removed-behavior·cross-file 3각도): SQL 문자단위 동일·인자 순서 보존·수신자 타입 정확 확인, **버그 0건**.

## ⚠ JSP 런타임 스모크 테스트 필요 (Tomcat 런타임 검증 불가 환경)
- [ ] 휴게소 상세에서 즐겨찾기 추가/해제(하트 토글)
- [ ] 하트 여부 표시(checkfavorite AJAX `{"fav":n}`)
- [ ] 마이페이지 즐겨찾기 목록 표시(favlist)
- [ ] 마이페이지 개별 삭제(favdelete, 본인 소유분만)
- [ ] 비로그인 가드(403) 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)
