### PR TITLE
리팩터(휴게소): JSP 위생 마무리(title 잔재·죽은 코드 정리)

### DIFF
--- a/src/main/webapp/hugesoinfo/hugesoaddaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoaddaction.jsp
@@ -127,7 +127,7 @@
 			}
 		}
 		
-		//공지사항 목록으로 이동
+		//휴게소 목록으로 이동
 		response.sendRedirect("../index.jsp?main=hugesoinfo/hugesolist.jsp");
 
 	 } catch(Exception e) {

--- a/src/main/webapp/hugesoinfo/hugesoaddform.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoaddform.jsp
@@ -11,7 +11,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=b71304786948cbe7995d40be3007bd8e&libraries=services"></script>
-<title>Insert title here</title>
+<title>휴게소 등록</title>
 	<style type="text/css">
 		#area{
 			margin-top: 20px;

--- a/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
+++ b/src/main/webapp/hugesoinfo/hugesodeleteaction.jsp
@@ -1,4 +1,3 @@
-<%@page import="hugesoinfo.model.HugesoInfoDto"%>
 <%@page import="hugesoinfo.model.HugesoInfoDao"%>
 <%@page import="food.model.FoodDto"%>
 <%@page import="food.model.FoodDao"%>
@@ -53,7 +52,6 @@
 	fdao.deleteHugesoFood(h_num);
 	
 	HugesoInfoDao hdao=new HugesoInfoDao();
-	HugesoInfoDto hdto=new HugesoInfoDto();
 	
 	//휴게소 파일삭제
 	String filePath=uploadPath+"/"+hdao.selectData(h_num).getH_photo();

--- a/src/main/webapp/hugesoinfo/hugesomap.jsp
+++ b/src/main/webapp/hugesoinfo/hugesomap.jsp
@@ -12,7 +12,7 @@
 	<link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic&display=swap" rel="stylesheet">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 	<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=b71304786948cbe7995d40be3007bd8e"></script>
-<title>Insert title here</title>
+<title>휴게소 찾기</title>
 	<style type="text/css">
 		#area{
 			margin-top: 7%;

--- a/src/main/webapp/hugesoinfo/hugesomap.jsp
+++ b/src/main/webapp/hugesoinfo/hugesomap.jsp
@@ -419,10 +419,6 @@
 	        		//각페이지당 출력할 시작번호 구하기
 	        		//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
 	        		no=totalCount-(currentPage-1)*perPage;
-
-	        		//각페이지당 출력할 시작번호 구하기
-	        		//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	        		no=totalCount-(currentPage-1)*perPage;
 	        		
 	        		var s="<ul class='pagination justify-content-center'>";
 	        		

--- a/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
+++ b/src/main/webapp/hugesoinfo/hugesoupdateform.jsp
@@ -18,7 +18,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=b71304786948cbe7995d40be3007bd8e&libraries=services"></script>
-<title>Insert title here</title>
+<title>휴게소 수정</title>
 <%
 	String h_num=request.getParameter("h_num");
 


### PR DESCRIPTION
## 배경
2단계 컨벤션 일관화에서 휴게소(hugesoinfo) 도메인은 DAO/DTO 리팩터(PR #75)가 끝났으나, **DAO 중심 패스라 손대지 않은 JSP 위생**이 남아 있었다. 이번 PR은 그 finishable 위생만 정리한다.

> **범위 결정**: 헤드라인 🔧 항목인 4종 list JSP(hugesolist/list2/listsearch/list2search) 구조적 통합과 페이징 스크립틀릿 공통 추출은 **Tomcat 런타임 검증 불가**로 보류(무검증 통합은 동작 보존 위배). 이번 PR은 동작 보존이 자명한 위생만 다룬다.

## 변경 내용 (커밋 2개)
1. **title 잔재 교체 3곳** — `<title>Insert title here</title>` → 실제 제목
   - hugesoaddform → "휴게소 등록", hugesomap → "휴게소 찾기", hugesoupdateform → "휴게소 수정"
2. **죽은 코드/주석 정리**
   - hugesomap.jsp: getPagingList의 **중복 `no=` 계산 1벌 제거**(두 블록 byte-identical, `hugesolist.jsp:227-229` 선례와 동형)
   - hugesodeleteaction.jsp: 생성만 하고 미사용인 **죽은 변수 `HugesoInfoDto hdto` 제거** + 이로써 죽은 **import `hugesoinfo.model.HugesoInfoDto` 제거**
   - hugesoaddaction.jsp: 리다이렉트 대상과 어긋난 주석 "공지사항 목록으로 이동" → "휴게소 목록으로 이동"

## 보존 (불변)
- 관리자 가드(`isAdmin`)·`isPost`·`checkCsrf`·`validateAllUploads`·멀티파트 업로드 검증·`escapeHtml`(mapaction/searchaction/hugesopaging/contentprogressbar) 전부 불변.
- DAO/DTO·4종 list JSP·hugesodetail 등은 미접촉.

## 검증
- **javac EXIT=0**(이번 PR은 JSP만 변경 → .java 트리 불변, #86 머지 후 baseline 컴파일 확인).
- **/simplify**(reuse·simplification·efficiency·altitude 4각도): in-scope findings 0. 잔여 관찰(hugesomap의 완전 미사용 `no`/`startNum` 변수, hugesodeleteaction의 `bdto`/`fdto` 죽은 초기화)은 **보수적 선례 범위 초과 + JSP라 검증 불가**라 백로그로 이관(아래 참조).
- **/code-review(high)**(line-scan·removed-behavior·cross-file 3각도): `hdto`/import 제거 안전(잔존 참조 0), 중복 `no=` byte-identical 확인, title/주석 plain text라 태그 무손상 → **버그 0건**.

## ⚠ JSP 런타임 스모크 테스트 필요 (Tomcat 검증 불가 환경)
- [ ] 휴게소 등록 폼/처리(관리자), 수정 폼/처리, 삭제(파일+DB)
- [ ] 휴게소 지도(hugesomap) 로딩·마커·페이징·검색(searchaction)
- [ ] 변경한 3개 폼/맵 페이지 `<title>` 표시

## 범위 외 (별도 PR / 백로그)
- **hugesodeleteaction.jsp:19 파일삭제 경로 불일치**: `getServletContext().getRealPath("/hugesosave")`(웹루트 내부)를 쓰는데 업로드는 외부 `AppConfig.getUploadPath("hugeso")`에 저장 → **실제 파일 미삭제**. 쇼핑 #85에서 스코프 아웃한 것과 **동일 클래스 버그**. 동작변경+런타임검증 필요라 별도 PR/보안백로그.
- hugesomap/hugesopaging 페이징 스크립틀릿 공통 추출 + 4종 list JSP 구조 통합 — Tomcat 보류.
- hugesomap의 완전 미사용 `no`/`startNum`/중복 `var startPage`, hugesodeleteaction `bdto`/`fdto` 죽은 초기화 — pre-existing·JSP 검증 불가라 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
