### PR TITLE
도구: JSP 프리컴파일 검증 게이트(JspC) 추가 — Tomcat 런타임 없이 JSP 오류 검출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.smarttomcat/
 *.iml
 
+# JSP 프리컴파일 게이트(scripts/jspc-check.ps1) 임시 산출물
+/.jspc/
+
 # 실제 설정 파일(비밀 포함) — 예시(db.properties.example)만 커밋한다
 db.properties
 *.local.properties

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,39 @@
+# scripts — 개발/검증 보조 스크립트
+
+## jspc-check.ps1 — JSP 프리컴파일 검증 게이트
+
+Tomcat을 띄우지 않고도 **모든 JSP의 변환(translation) + Java 컴파일 오류**를 한 번에 잡는다.
+Apache Jasper(`org.apache.jasper.JspC`)로 `src/main/webapp`의 모든 `*.jsp`를 서블릿 코드로
+변환하고 컴파일(`-compile`)한다.
+
+### 왜 필요한가
+- 기존 정적 검증은 `javac`로 `src/main/java`(DAO/DTO/util)만 확인했다 → **JSP는 무검증**이었다.
+- 그래서 Tomcat 런타임 검증이 불가한 환경에서는 구조적 JSP 작업(페이징 스크립틀릿 `include`
+  추출, `hugesolist` 4종 통합, 공용 CSS/탭 분리)을 "동작 보존 위배 위험"으로 **보류**해 왔다.
+- 이 게이트는 그 보류 작업의 **1순위 위험**을 런타임 없이 잡아 재개 가능하게 한다:
+  - JSP 변환 오류: 스크립틀릿/EL 문법, `<%@ include %>` 변수 중복선언·스코프 충돌
+  - JSP→DAO 호출 오류: JSP가 부르는 DAO 메서드 이름/시그니처 불일치(예: 메서드 이름 변경 후
+    JSP 호출처 누락) — **`javac`로는 못 잡고 런타임 ClassNotFound/NoSuchMethod로 터지던 것**
+
+### 한계 (이건 못 잡는다 → 여전히 실제 구동 필요)
+런타임 동작: SQL 결과, redirect 대상, AJAX URL 정합, 세션/로그인 흐름, DB 데이터 의존 화면.
+→ end-to-end는 IntelliJ + Tomcat(+MySQL 시드) 수동 스모크 또는 Docker 스택으로 별도 검증.
+
+### 사전조건
+- Java 17 (`javac`/`java` on PATH)
+- Apache Tomcat 9 설치(Jasper 제공). `CATALINA_HOME` 환경변수 설정 권장.
+  미설정 시 스크립트가 기본 경로(`C:\ApacheTomcat\apache-tomcat-9.0.118`)를 시도한다.
+  다른 환경이면 `CATALINA_HOME`을 설정하거나 스크립트의 `$cands` 목록을 수정한다.
+- 인터넷(최초 1회): `ant.jar` 자동 다운로드 → `.jspc/lib`에 캐시.
+  ※ `JspC`가 `org.apache.tools.ant.Task`를 링크하므로 `ant.jar`가 classpath에 반드시 필요하다.
+
+### 실행
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/jspc-check.ps1
+```
+- 종료코드 `0` = 전 JSP 통과(오류 0), 그 외 = 실패(오류 로그 출력).
+- 임시 산출물은 `.jspc/`(gitignore). 안전하게 삭제 가능, 다음 실행 시 재생성.
+
+### 권장 사용 시점
+- JSP를 만지는 모든 PR(특히 구조 통합·`include` 추출) 직후, 커밋 전.
+- 기존 베이스라인은 **오류 0(green)** 임이 확인됨(전체 122개 JSP 통과). 새로 깨지면 그 변경이 원인.

--- a/scripts/jspc-check.ps1
+++ b/scripts/jspc-check.ps1
@@ -1,0 +1,123 @@
+<#
+.SYNOPSIS
+  JSP precompilation gate - validate all JSPs (translation + Java compile) without
+  running Tomcat or a DB.
+
+.DESCRIPTION
+  Uses Apache Jasper (org.apache.jasper.JspC) to translate every *.jsp under
+  src/main/webapp into servlet .java and compile them (-compile). This catches what
+  plain `javac` (which only checks src/main/java) cannot:
+    - JSP translation errors: scriptlet/EL syntax, <%@ include %> variable
+      redeclaration / scope clashes
+    - JSP -> DAO call errors: a JSP calling a DAO method whose name/signature no
+      longer exists (e.g. after a rename) - otherwise only surfaces at runtime.
+  Use as a regression gate when doing structural JSP work (paging-scriptlet include
+  extraction, hugesolist consolidation) in an environment where Tomcat runtime
+  verification is unavailable.
+  NOT covered (still needs a real run): runtime behavior - SQL results, redirect
+  targets, AJAX URL correctness, session/login flow, DB-data-dependent screens.
+
+  See scripts/README.md (Korean) for the full rationale.
+
+.NOTES
+  Prerequisites:
+    - Java 17 (javac/java on PATH)
+    - Apache Tomcat 9 install (provides Jasper). Set CATALINA_HOME, or edit $cands.
+    - Internet (first run only): downloads ant.jar, cached under .jspc/lib.
+      JspC links org.apache.tools.ant.Task, so ant.jar must be on the classpath.
+  Run:  powershell -ExecutionPolicy Bypass -File scripts/jspc-check.ps1
+  Exit: 0 = all JSPs pass, non-zero = failure (error log printed).
+
+  ASCII-only on purpose: Windows PowerShell 5.1 reads a BOM-less .ps1 as the system
+  ANSI codepage, which corrupts non-ASCII source. Korean docs live in README.md.
+
+  Note: JspC returns exit code 0 even when JSPs fail to compile, so this script
+  judges pass/fail by generated output (every .java must have a matching .class),
+  not by the process exit code.
+#>
+# 'Continue' on purpose: under 'Stop', PS 5.1 promotes a native exe's stderr line
+# (e.g. Jasper's TldScanner INFO log) to a terminating error. Control flow below
+# relies on explicit checks, not $ErrorActionPreference.
+$ErrorActionPreference = 'Continue'
+
+# --- paths ---
+$proj      = Split-Path -Parent $PSScriptRoot          # repo root (parent of scripts/)
+$webapp    = Join-Path $proj 'src\main\webapp'
+$weblibDir = Join-Path $webapp 'WEB-INF\lib'
+$work      = Join-Path $proj '.jspc'                   # temp output (gitignored)
+$classes   = Join-Path $work 'classes'
+$gen       = Join-Path $work 'gen'
+$libCache  = Join-Path $work 'lib'
+
+# --- locate Tomcat 9 (CATALINA_HOME first, else known default) ---
+$tom = $env:CATALINA_HOME
+if (-not $tom -or -not (Test-Path (Join-Path $tom 'lib\jasper.jar'))) {
+    $cands = @(
+        'C:\ApacheTomcat\apache-tomcat-9.0.118'   # this machine; set CATALINA_HOME elsewhere
+    )
+    $tom = $cands | Where-Object { Test-Path (Join-Path $_ 'lib\jasper.jar') } | Select-Object -First 1
+}
+if (-not $tom) {
+    Write-Output "[jspc] ERROR: Tomcat 9 not found. Set CATALINA_HOME to a Tomcat 9 install."
+    exit 2
+}
+Write-Output "[jspc] Tomcat: $tom"
+
+# --- reset work dirs ---
+foreach ($d in @($classes, $gen, $libCache)) {
+    if (Test-Path $d) { Remove-Item $d -Recurse -Force }
+    New-Item -ItemType Directory $d | Out-Null
+}
+
+# --- ensure ant.jar (JspC links org.apache.tools.ant.Task); cached ---
+$antJar = Join-Path $libCache 'ant-1.10.14.jar'
+if (-not (Test-Path $antJar)) {
+    Write-Output "[jspc] downloading ant.jar (first run only)..."
+    try {
+        Invoke-WebRequest -Uri 'https://repo1.maven.org/maven2/org/apache/ant/ant/1.10.14/ant-1.10.14.jar' `
+            -OutFile $antJar -UseBasicParsing -TimeoutSec 120 -ErrorAction Stop
+    } catch {
+        Write-Output "[jspc] ERROR: ant.jar download failed: $($_.Exception.Message)"
+        exit 3
+    }
+}
+
+# --- 1) compile project java (needed so -compile can type-check JSP->DAO calls) ---
+$servletApi = Join-Path $tom 'lib\servlet-api.jar'
+$weblib = (Get-ChildItem $weblibDir -Filter *.jar | ForEach-Object FullName) -join ';'
+$srcs = Get-ChildItem (Join-Path $proj 'src\main\java') -Recurse -Filter *.java | ForEach-Object FullName
+Write-Output "[jspc] compiling project java..."
+& javac -encoding UTF-8 -cp "$servletApi;$weblib" -d $classes $srcs
+if ($LASTEXITCODE -ne 0) { Write-Output "[jspc] ERROR: javac failed (EXIT=$LASTEXITCODE)"; exit 1 }
+
+# --- 2) run JspC (translate + compile entire webapp) ---
+$tomcp = (((Get-ChildItem (Join-Path $tom 'lib') -Filter *.jar | ForEach-Object FullName)) `
+    + (Join-Path $tom 'bin\tomcat-juli.jar') + $antJar) -join ';'
+$appcp = "$classes;$weblib"
+$log = Join-Path $work 'jspc.err'
+Write-Output "[jspc] running JspC (translate + compile)..."
+# -Duser.language=en: English JspC/JDT messages (avoid console locale mojibake).
+& java '-Duser.language=en' -cp $tomcp org.apache.jasper.JspC -webapp $webapp -d $gen -javaEncoding UTF-8 -compile -classpath $appcp 2>$log 1>$null
+
+# --- 3) verdict by output, NOT exit code (JspC exits 0 even on compile errors) ---
+#   translation failure: #jsp > #generated .java
+#   compile failure    : a generated X.java has no matching X.class
+$jspCount = (Get-ChildItem $webapp -Recurse -Filter *.jsp | Measure-Object).Count
+$javas = @(Get-ChildItem $gen -Recurse -Filter *.java)
+$missing = @($javas | Where-Object { -not (Test-Path ([System.IO.Path]::ChangeExtension($_.FullName, 'class'))) })
+$translationFail = $jspCount - $javas.Count
+
+if ($missing.Count -eq 0 -and $translationFail -le 0) {
+    Write-Output "[jspc] PASS - $jspCount JSP translated + compiled, 0 errors"
+    exit 0
+} else {
+    Write-Output "[jspc] FAIL - translation failures: $translationFail, compile failures: $($missing.Count)"
+    if ($missing.Count -gt 0) {
+        Write-Output "[jspc] failed compiles (generated .java; names are JspC-mangled):"
+        $missing | ForEach-Object { Write-Output ("  - " + $_.Name) }
+    }
+    Write-Output "[jspc] error log (key lines):"
+    Get-Content $log | Where-Object { $_ -match '\.java:|ERROR|cannot|undefined|method|symbol|Unable' } | Select-Object -First 40
+    Write-Output "[jspc] full log: $log"
+    exit 1
+}


### PR DESCRIPTION
## 배경
2단계 리팩터링 내내 **"Tomcat 런타임 검증 불가"** 때문에 구조적 JSP 작업(페이징 스크립틀릿 `include` 추출, `hugesolist` 4종 통합, 공용 CSS/탭 분리)을 보류해 왔다. 원인은 정적 검증이 `javac`(= `src/main/java`만)뿐이라 **JSP가 전혀 검증되지 않았던** 것.

이 PR은 그 공백을 메우는 **JSP 프리컴파일 게이트**를 추가한다. Tomcat을 띄우지 않고 전체 JSP를 변환+컴파일해 오류를 잡는다.

## 무엇을 잡나 (javac가 못 잡던 것)
- **JSP 변환 오류**: 스크립틀릿/EL 문법, `<%@ include %>` 변수 중복선언·스코프 충돌 → 보류 작업의 1순위 위험
- **JSP→DAO 호출 오류**: JSP가 부르는 DAO 메서드 이름/시그니처 불일치(예: 메서드 이름 변경 후 JSP 호출처 누락) — 지금까지 런타임에서야 터지던 것

## 한계 (여전히 실제 구동 필요)
런타임 동작(SQL 결과, redirect 대상, AJAX URL, 세션/로그인, DB 데이터 의존 화면)은 검증 못 함 → end-to-end는 IntelliJ+Tomcat 수동 스모크 또는 Docker 스택으로 별도 검증.

## 구현 (`scripts/jspc-check.ps1` + `scripts/README.md`)
- Apache Jasper `org.apache.jasper.JspC`로 `src/main/webapp` 전체 변환 후 `-compile`.
- **기존 Tomcat 9 설치의 jasper jar 사용**(`CATALINA_HOME` 또는 기본경로 `C:\ApacheTomcat\apache-tomcat-9.0.118`). **mvn 불필요**(이 환경엔 mvn 없음).
- JspC가 `org.apache.tools.ant.Task`를 링크 → `ant.jar` 필요 → **최초 1회 자동 다운로드**(`.jspc/lib` 캐시). (메모상 "JspC는 Ant 없어 불가"였던 원인을 이렇게 해소)
- ⚠ **JspC는 컴파일 오류가 있어도 프로세스 종료코드 0을 반환** → 종료코드 대신 **"생성된 `.java` 대비 `.class` 누락"** 으로 판정(견고·로캘 무관).
- 스크립트는 **ASCII 전용**: PS 5.1이 BOM 없는 UTF-8 `.ps1`을 ANSI 코드페이지로 읽어 한글이 깨지는 문제 회피(한글 설명은 `README.md`에). `$ErrorActionPreference='Continue'`로 네이티브 stderr가 종료성 오류로 승격되는 PS 5.1 함정도 회피.
- `.gitignore`에 임시 산출물 `/.jspc/` 추가.

## 검증 (게이트가 진짜 동작함)
- **음성 테스트**: 존재하지 않는 DAO 메서드를 호출하는 임시 JSP 투입 → **FAIL(exit 1)** + 정확한 위치 출력:
  `The method __definitely_no_such_method__() is undefined for the type MemInfoDao` (line 3, /__jspc_selftest.jsp). 임시 파일은 검증 후 삭제.
- **정상 트리**: **PASS(exit 0)** — 현재 122개 JSP 전부 변환+컴파일 성공(green 베이스라인).

## 사용
```powershell
powershell -ExecutionPolicy Bypass -File scripts/jspc-check.ps1
```
JSP를 만지는 PR(특히 구조 통합·include 추출) 직후 커밋 전 실행. 새로 깨지면 그 변경이 원인.

## 효과
보류했던 휴게소 4종 list 통합·페이징 include 추출을 이제 **이 게이트로 변환·메서드 수준까지 검증하며 재개**할 수 있다(런타임 동작은 IntelliJ 스모크 병행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
