### PR TITLE
리팩터: 페이징 스크립틀릿 공통 include 추출(게시판 4 + 휴게소 4)

### DIFF
--- a/scripts/jspc-check.ps1
+++ b/scripts/jspc-check.ps1
@@ -102,7 +102,10 @@ Write-Output "[jspc] running JspC (translate + compile)..."
 # --- 3) verdict by output, NOT exit code (JspC exits 0 even on compile errors) ---
 #   translation failure: #jsp > #generated .java
 #   compile failure    : a generated X.java has no matching X.class
-$jspCount = (Get-ChildItem $webapp -Recurse -Filter *.jsp | Measure-Object).Count
+# NOTE: -Filter *.jsp uses legacy DOS wildcard matching and ALSO matches *.jspf/*.jspx
+# (the classic *.doc->*.docx gotcha). JspC only translates standalone *.jsp, so .jspf
+# include fragments must be excluded here or jspCount > generated .java -> false failure.
+$jspCount = (Get-ChildItem $webapp -Recurse -Filter *.jsp | Where-Object { $_.Extension -eq '.jsp' } | Measure-Object).Count
 $javas = @(Get-ChildItem $gen -Recurse -Filter *.java)
 $missing = @($javas | Where-Object { -not (Test-Path ([System.IO.Path]::ChangeExtension($_.FullName, 'class'))) })
 $translationFail = $jspCount - $javas.Count

--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -129,41 +129,9 @@
 	int totalCount=dao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호
-	
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-	
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-	
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-	
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-	
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-	
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 	
 	//페이지에서 보여질 글만 가져오기
 	List<EventDto> list = dao.selectPagingList(startNum, perPage);
@@ -261,41 +229,8 @@
   
   
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=eventboard/eventList.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=eventboard/eventList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=eventboard/eventList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=eventboard/eventList.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="eventboard/eventList.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
  
   
 </div>

--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -188,41 +188,9 @@ color: black;
 	int totalCount=hdao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호
-
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=hdao.selectPagingList(startNum, perPage);
@@ -445,41 +413,8 @@ for(int i=0;i<list2.size();i++){
 	%>
 </div>
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolist.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="hugesoinfo/hugesolist.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
 
 </div>
 <div id="searcharea">

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -138,41 +138,9 @@ a:active{
 	int totalCount=dao.selectTotalCount();
 	int perPage=9; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호
-
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=dao.selectPagingList(startNum, perPage);
@@ -298,41 +266,8 @@ for (int i = 0; i < list2.size(); i++) {
 </div>
 
 <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="hugesoinfo/hugesolist2.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
   
 
 </div>

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -103,41 +103,9 @@ a:active{
 	int totalCount=dao.selectSearchTotalCount(h_name);
 	int perPage=9; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호
-
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=dao.selectSearchPagingList(h_name, startNum, perPage);
@@ -270,41 +238,8 @@ if(list2.isEmpty()){
 </div>
 
 <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=startPage-1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolist2search.jsp?currentPage=<%=endPage+1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="hugesoinfo/hugesolist2search.jsp"; String pageQuery="&h_name="+util.SecurityUtil.urlEncode(h_name); %>
+<%@ include file="/layout/pagingNav.jspf" %>
   
 
 </div>

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -151,41 +151,9 @@ color: black;
 	int totalCount=hdao.selectSearchTotalCount(h_name);
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=5; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호
-
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 
 	//페이지에서 보여질 글만 가져오기
 	List<HugesoInfoDto>list2=hdao.selectSearchPagingList(h_name, startNum, perPage);
@@ -414,41 +382,8 @@ if(list2.isEmpty()){
 	%>
 </div>
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=startPage-1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=pp%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=hugesoinfo/hugesolistsearch.jsp?currentPage=<%=endPage+1%>&h_name=<%=util.SecurityUtil.urlEncode(h_name) %>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="hugesoinfo/hugesolistsearch.jsp"; String pageQuery="&h_name="+util.SecurityUtil.urlEncode(h_name); %>
+<%@ include file="/layout/pagingNav.jspf" %>
 
 </div>
 <div id="searcharea">

--- a/src/main/webapp/layout/pagingCalc.jspf
+++ b/src/main/webapp/layout/pagingCalc.jspf
@@ -1,0 +1,24 @@
+<%-- 페이징 계산 공통 프래그먼트 (정적 <%@ include %> 전용).
+     입력(호출 JSP가 include 전에 선언해야 함): int totalCount, perPage, perBlock
+     출력(이 프래그먼트가 선언): int currentPage, totalPage, startPage, endPage, startNum, no --%>
+<%
+	//현재페이지 읽되 null이면 1페이지로 준다
+	int currentPage;
+	if(request.getParameter("currentPage")==null)
+		currentPage=1;
+	else
+		currentPage=Integer.parseInt(request.getParameter("currentPage"));
+
+	//총페이지수(나머지가 있으면 +1페이지)
+	int totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
+
+	//각 블럭당 보여질 시작/끝 페이지
+	int startPage=(currentPage-1)/perBlock*perBlock+1;
+	int endPage=startPage+perBlock-1;
+	if(endPage>totalPage)
+		endPage=totalPage;
+
+	//db에서 가져올 글의 시작번호 / 화면에 출력할 시작번호
+	int startNum=(currentPage-1)*perPage;
+	int no=totalCount-(currentPage-1)*perPage;
+%>

--- a/src/main/webapp/layout/pagingNav.jspf
+++ b/src/main/webapp/layout/pagingNav.jspf
@@ -1,0 +1,40 @@
+<%-- 페이지 번호 출력 공통 프래그먼트 (정적 <%@ include %> 전용).
+     입력: int startPage, endPage, currentPage, totalPage; String pageUrl, pageQuery
+       - pageUrl  : index.jsp?main= 뒤에 올 대상 JSP 경로(예: "noticeboard/noticeList.jsp")
+       - pageQuery: currentPage 뒤에 덧붙일 추가 쿼리. 없으면 "", 있으면 "&키=값" 형태로
+                    이미 인코딩해 전달(예: "&h_name="+util.SecurityUtil.urlEncode(h_name))
+     href = index.jsp?main=<pageUrl>?currentPage=<n><pageQuery> --%>
+<ul class="pagination justify-content-center">
+<%
+	//이전
+	if(startPage>1)
+	{%>
+		<li class="page-item ">
+		 <a class="page-link" href="index.jsp?main=<%=pageUrl%>?currentPage=<%=startPage-1%><%=pageQuery%>" style="color: black;">이전</a>
+		</li>
+	<%}
+	for(int pp=startPage;pp<=endPage;pp++)
+	{
+		if(pp==currentPage)
+		{%>
+			<li class="page-item active">
+			<a class="page-link" href="index.jsp?main=<%=pageUrl%>?currentPage=<%=pp%><%=pageQuery%>"><%=pp %></a>
+			</li>
+		<%}else
+		{%>
+			<li class="page-item">
+			<a class="page-link" href="index.jsp?main=<%=pageUrl%>?currentPage=<%=pp%><%=pageQuery%>"><%=pp %></a>
+			</li>
+		<%}
+	}
+
+	//다음
+	if(endPage<totalPage)
+	{%>
+		<li class="page-item">
+			<a  class="page-link" href="index.jsp?main=<%=pageUrl%>?currentPage=<%=endPage+1%><%=pageQuery%>"
+			style="color: black;">다음</a>
+		</li>
+	<%}
+%>
+</ul>

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -129,41 +129,9 @@
 	int totalCount=dao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호
-	
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-	
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-	
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-	
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-	
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-	
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 	
 	//페이지에서 보여질 글만 가져오기
 	List<NoticeDto> list = dao.selectPagingList(startNum, perPage);
@@ -267,41 +235,8 @@
   
   
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=noticeboard/noticeList.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=noticeboard/noticeList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=noticeboard/noticeList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=noticeboard/noticeList.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="noticeboard/noticeList.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
  
   
 </div>

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -127,41 +127,9 @@
 	int totalCount=dao.selectTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호 
-	
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-	
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-	
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-	
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-	
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-	
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 	
 	//페이지에서 보여질 글만 가져오기
 	List<QaDto> list = dao.selectPagingList(startNum, perPage);
@@ -305,41 +273,8 @@ $(function(){
   
   
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=qaboard/qaList.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=qaboard/qaList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=qaboard/qaList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=qaboard/qaList.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="qaboard/qaList.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
  
   
 </div>

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -166,41 +166,9 @@
 	int totalCount=dao.selectTotalCount();
 	int perPage=5; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호 
-	
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-	
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-	
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-	
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-	
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-	
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 	
 	//페이지에서 보여질 글만 가져오기
 	List<ReviewDto> list = dao.selectPagingList(startNum, perPage);
@@ -321,41 +289,8 @@
    <div style="margin:0 auto; width: 800px; margin-top: 3%; margin-bottom:3%; text-align: center;" id="pagelayout">
 
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=reviewboard/reviewList.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=reviewboard/reviewList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=reviewboard/reviewList.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=reviewboard/reviewList.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-  %>
-  
-  </ul>
+  <% String pageUrl="reviewboard/reviewList.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
  
   
 </div>


### PR DESCRIPTION
## 개요
게시판·휴게소 목록 JSP에 복붙돼 있던 **페이징 계산 스크립틀릿**과 **페이지 번호 출력 블록**을 정적 `<%@ include %>` 프래그먼트 2개로 추출했습니다. 2단계 리팩터링 playbook의 전역(공통) 🔁 "페이징 include 추출" 항목으로, JspC 게이트(PR #89) 확보 후 재개한 첫 구조 작업입니다. **동작·출력 HTML 보존이 원칙인 순수 리팩터**입니다.

## 변경 내용
**신설 프래그먼트** (`src/main/webapp/layout/`)
- `pagingCalc.jspf` — 입력 `totalCount/perPage/perBlock` → 출력 `currentPage/totalPage/startPage/endPage/startNum/no`
- `pagingNav.jspf` — 입력 `pageUrl/pageQuery` + 계산결과 → `<ul class="pagination">` 이전/번호/다음

**적용 8파일**
| 파일 | perPage | perBlock | pageQuery |
|---|---|---|---|
| noticeList / eventList / qaList | 10 | 10 | "" |
| reviewList | 5 | 10 | "" |
| hugesolist | 10 | 5 | "" |
| hugesolist2 | 9 | 5 | "" |
| hugesolistsearch | 10 | 5 | `&h_name=`+urlEncode |
| hugesolist2search | 9 | 5 | `&h_name=`+urlEncode |

`perPage/perBlock`는 파일별로 달라 host 입력으로 유지. 검색 변형 2종은 nav href에 검색어가 유지되도록 `pageQuery`로 인코딩된 `&h_name` 접미사 전달(기존 출력과 동일). 빈페이지 redirect는 URL이 파일별이라 host에 그대로 둠.

**부수 변경**
- `scripts/jspc-check.ps1` — PowerShell `-Filter *.jsp`가 DOS 와일드카드로 `.jspf`까지 오집계하던 것을 `Where-Object Extension -eq '.jsp'`로 보정(프래그먼트 도입의 사전 인프라).

## 제외(설계상)
- **`hugesomap.jsp`** — 페이징이 클라이언트 JS(`getPagingList()` AJAX)라 Java 스크립틀릿 프래그먼트와 패턴 불일치 → 제외.
- mypage 탭 목록(my/admin*) — 탭 UI 통합은 playbook 별도 항목.

## 검증(에이전트)
- ✅ javac / **JspC 게이트 EXIT=0** (122 JSP 변환+컴파일, 0 errors) — include 변수 스코프·JSP→DAO 시그니처 검증
- ✅ `/simplify`(reuse·simplification·efficiency·altitude 4각도) — 검색 페이지는 `urlEncode` 호출이 페이지당 1회로 줄어 소폭 개선. 계약 주석 1건 보강
- ✅ `/code-review high`(line-scan·removed-behavior·cross-file 3각도) — **버그 0건**. 계산식·href 출력·스코프·include 순서 동일성 확인

## ⚠ JSP 런타임 스모크 체크리스트 (IntelliJ+Tomcat에서 확인 부탁)
JspC는 런타임(href 이동·검색·CSS·JS·SQL)을 못 잡습니다. 아래만 육안 확인 부탁드립니다.
- [ ] **게시판 4종**: 목록 표시, 번호(no) 역순, 이전/번호/다음 페이지 이동, 마지막 글 삭제 후 이전 페이지 복귀(redirect), 글쓰기 버튼 권한
- [ ] **휴게소**: hugesolist(목록형)·hugesolist2(앨범형) 페이징, 목록↔앨범 토글, 휴게소 상세 이동
- [ ] **검색 페이징(핵심)**: 검색 후 hugesolistsearch·hugesolist2search에서 2페이지 이동 시 **검색어(&h_name) 유지**되는지(=pageQuery 정확성)

## 참고(범위 외)
- `noticeList.jsp` 빈페이지 redirect가 `qaboard/noticeList.jsp`(잘못된 디렉토리)로 감 — **기존 복붙 버그**. host redirect는 추출하지 않아 그대로 보존했고, 별도 정리 후보입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
