### PR TITLE
refactor: 마이페이지 탭 UI/JS + 페이징 스크립틀릿 공통 include 추출

### DIFF
--- a/src/main/webapp/layout/mypageAdminTabs.jspf
+++ b/src/main/webapp/layout/mypageAdminTabs.jspf
@@ -1,0 +1,31 @@
+<%-- 마이페이지 관리자 탭(Q&A / NOTICE / EVENT) 공통 프래그먼트 (정적 <%@ include %> 전용).
+     입력(호출 JSP가 include 전에 선언해야 함): String adminTab ∈ {"qa","notice","event"} — 현재 활성 탭.
+     활성 탭 강조 CSS(id별 초록)는 각 host의 <style>에 그대로 두고, 여기서는
+     현재 탭이 아닌 탭에만 클릭 핸들러를 등록해 해당 목록으로 이동시킨다. --%>
+<ul class="tabs">
+	<li id="first"><span style="font-size: 14px;">Q&A</span></li>
+	<li id="next"><span style="font-size: 14px;">NOTICE</span></li>
+	<li id="event"><span style="font-size: 14px;">EVENT</span></li>
+</ul>
+<script type="text/javascript">
+	$(function(){
+		<% if(!"qa".equals(adminTab)) { %>
+		//Q&A 탭 클릭 시 관리자 Q&A 답변 목록으로 이동
+		$("#first").click(function(){
+			location.href="index.jsp?main=mypage/adminqnalist.jsp";
+		});
+		<% } %>
+		<% if(!"notice".equals(adminTab)) { %>
+		//NOTICE 탭 클릭 시 공지 관리 목록으로 이동
+		$("#next").click(function(){
+			location.href="index.jsp?main=mypage/adminnoticelist.jsp";
+		});
+		<% } %>
+		<% if(!"event".equals(adminTab)) { %>
+		//EVENT 탭 클릭 시 이벤트 관리 목록으로 이동
+		$("#event").click(function(){
+			location.href="index.jsp?main=mypage/admineventlist.jsp";
+		});
+		<% } %>
+	});
+</script>

--- a/src/main/webapp/layout/mypageTabs.jspf
+++ b/src/main/webapp/layout/mypageTabs.jspf
@@ -1,0 +1,23 @@
+<%-- 마이페이지 사용자 탭(Q&A / REVIEW) 공통 프래그먼트 (정적 <%@ include %> 전용).
+     입력(호출 JSP가 include 전에 선언해야 함): String mypageTab ∈ {"qa","review"} — 현재 활성 탭.
+     활성 탭 강조 CSS(id별 초록)는 각 host의 <style>에 그대로 두고, 여기서는
+     비활성 탭에만 클릭 핸들러를 등록해 다른 목록으로 이동시킨다. --%>
+<ul class="tabs">
+	<li id="first"><span style="font-size: 14px;">Q&A</span></li>
+	<li id="next"><span style="font-size: 14px;">REVIEW</span></li>
+</ul>
+<script type="text/javascript">
+	$(function(){
+		<% if("qa".equals(mypageTab)) { %>
+		//Q&A 탭 활성 → REVIEW 탭 클릭 시 내 후기 페이지로 이동
+		$("#next").click(function(){
+			location.href="index.jsp?main=mypage/myreviewlist.jsp";
+		});
+		<% } else { %>
+		//REVIEW 탭 활성 → Q&A 탭 클릭 시 내 문의 페이지로 이동
+		$("#first").click(function(){
+			location.href="index.jsp?main=mypage/myqnalist.jsp";
+		});
+		<% } %>
+	});
+</script>

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -193,16 +193,6 @@ font-size: 14px;
 </style>
 <script type="text/javascript">
 	$(function(){
-		//메뉴탭기능 클릭하면 공지사항페이지로 이동
-		$("#first").click(function(){
-            location.href="index.jsp?main=mypage/adminqnalist.jsp";
-        });
-		//메뉴탭기능 클릭하면 이벤트페이지로 이동
-		$("#next").click(function(){
-            location.href="index.jsp?main=mypage/adminnoticelist.jsp";
-        });
-		
-		
 		 //전체체크 클릭시 체크값 얻어서 모든체크값 에 전달
 		  $(".alldelcheck").click(function(){
 			  
@@ -325,11 +315,8 @@ font-size: 14px;
 <div class="container">
 
 <div class="admineventlist">
-	<ul class="tabs">
-			<li id="first"><span style="font-size: 14px;">Q&A</span></li>
-			<li id="next"><span style="font-size: 14px;">NOTICE</span></li>
-			<li id="event"><span style="font-size: 14px;">EVENT</span></li>
-	</ul>
+	<% String adminTab="event"; %>
+	<%@ include file="/layout/mypageAdminTabs.jspf" %>
 	<div id="tab2" class="tab2" style="margin-top: 40px;">
       	<table class="table table-bordered">
          	<tr style="height: 30px;">

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -250,41 +250,9 @@ font-size: 14px;
 	int totalCount=dao.selectMyPageTotalCount();
 	int perPage=5; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호 
-	
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-	
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-	
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-	
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-	
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-	
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 	
 	//페이지에서 보여질 글만 가져오기
 	List<EventDto> list = dao.selectMyPageList(startNum, perPage);
@@ -384,42 +352,9 @@ font-size: 14px;
    <div id="pagelayout">
 
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=mypage/admineventlist.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=mypage/admineventlist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=mypage/admineventlist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=mypage/admineventlist.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-          }
-  %>
-  
-  </ul>
+  <% String pageUrl="mypage/admineventlist.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
+  <% } %>
  
   
 </div>

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -193,16 +193,6 @@ font-size: 14px;
 </style>
 <script type="text/javascript">
 	$(function(){
-		//메뉴탭기능 클릭하면 공지사항페이지로 이동
-		$("#first").click(function(){
-            location.href="index.jsp?main=mypage/adminqnalist.jsp";
-        });
-		//메뉴탭기능 클릭하면 이벤트페이지로 이동
-		$("#event").click(function(){
-            location.href="index.jsp?main=mypage/admineventlist.jsp";
-        });
-		
-		
 		 //전체체크 클릭시 체크값 얻어서 모든체크값 에 전달
 		  $(".alldelcheck").click(function(){
 			  
@@ -322,11 +312,8 @@ font-size: 14px;
 <div class="container">
 
 <div class="adminnoticelist">
-	<ul class="tabs">
-			<li id="first"><span style="font-size: 14px;">Q&A</span></li>
-			<li id="next"><span style="font-size: 14px;">NOTICE</span></li>
-			<li id="event"><span style="font-size: 14px;">EVENT</span></li>
-	</ul>
+	<% String adminTab="notice"; %>
+	<%@ include file="/layout/mypageAdminTabs.jspf" %>
 	<div id="tab2" class="tab2" style="margin-top: 40px;">
       	<table class="table table-bordered">
          	<tr style="height: 30px;">

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -250,41 +250,9 @@ font-size: 14px;
 	int totalCount=dao.selectMyPageTotalCount();
 	int perPage=5; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호 
-	
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-	
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-	
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-	
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-	
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-	
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 	
 	//페이지에서 보여질 글만 가져오기
 	List<NoticeDto> list = dao.selectMyPageList(startNum, perPage);
@@ -381,42 +349,9 @@ font-size: 14px;
    <div id="pagelayout">
 
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=mypage/adminnoticelist.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=mypage/adminnoticelist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=mypage/adminnoticelist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=mypage/adminnoticelist.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-          }
-  %>
-  
-  </ul>
+  <% String pageUrl="mypage/adminnoticelist.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
+  <% } %>
  
   
 </div>

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -190,16 +190,6 @@ font-size: 14px;
 </style>
 <script type="text/javascript">
 	$(function(){
-		//메뉴탭기능 클릭하면 공지사항페이지로 이동
-		$("#next").click(function(){
-            location.href="index.jsp?main=mypage/adminnoticelist.jsp";
-        });
-		//메뉴탭기능 클릭하면 이벤트페이지로 이동
-		$("#event").click(function(){
-            location.href="index.jsp?main=mypage/admineventlist.jsp";
-        });
-		
-		
 		 //전체체크 클릭시 체크값 얻어서 모든체크값 에 전달
 		  $(".alldelcheck").click(function(){
 			  
@@ -322,11 +312,8 @@ font-size: 14px;
 <div class="container">
 
 <div class="adminqnalist">
-	<ul class="tabs">
-			<li id="first"><span style="font-size: 14px;">Q&A</span></li>
-			<li id="next"><span style="font-size: 14px;">NOTICE</span></li>
-			<li id="event"><span style="font-size: 14px;">EVENT</span></li>
-	</ul>
+	<% String adminTab="qa"; %>
+	<%@ include file="/layout/mypageAdminTabs.jspf" %>
 	<div id="tab2" class="tab2" style="margin-top: 40px;">
       	<table class="table table-bordered">
          	<tr style="height: 30px;">

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -249,41 +249,9 @@ font-size: 14px;
 	int totalCount=dao.selectMyPageTotalCount();
 	int perPage=10; //한페이지당 보여질 글의 갯수
 	int perBlock=10; //한블럭당 보여질 페이지 갯수
-	int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-	int startPage; //각블럭당 보여질 시작페이지
-	int endPage; //각블럭당 보여질 끝페이지
-	int currentPage;  //현재페이지
-	int totalPage; //총페이지수
-	int no; //각페이지당 출력할 시작번호 
-	
-	//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-	if(request.getParameter("currentPage")==null)
-		currentPage=1;
-	else
-		currentPage=Integer.parseInt(request.getParameter("currentPage"));
-	
-	//총페이지수 구한다
-	//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-	//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-	totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-	
-	//각블럭당 보여질 시작페이지
-	//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-	//현재가 13일경우 시작:11 끝:15
-	startPage=(currentPage-1)/perBlock*perBlock+1;
-	endPage=startPage+perBlock-1;
-	
-	//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-	if(endPage>totalPage)
-		endPage=totalPage;
-	
-	//각페이지에서 보여질 시작번호
-	//1페이지:0, 2페이지:5 3페이지: 10.....
-	startNum=(currentPage-1)*perPage;
-	
-	//각페이지당 출력할 시작번호 구하기
-	//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-	no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 	
 	//페이지에서 보여질 글만 가져오기
 	List<QaanswerDto> list = dao.selectMyPageList(startNum, perPage);
@@ -379,42 +347,9 @@ font-size: 14px;
    <div id="pagelayout">
 
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-	  <li class="page-item ">
-	   <a class="page-link" href="index.jsp?main=mypage/adminqnalist.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-	  </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-    	if(pp==currentPage)
-    	{%>
-    		<li class="page-item active">
-    		<a class="page-link" href="index.jsp?main=mypage/adminqnalist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}else
-    	{%>
-    		<li class="page-item">
-    		<a class="page-link" href="index.jsp?main=mypage/adminqnalist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-    		</li>
-    	<%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-    	<li class="page-item">
-    		<a  class="page-link" href="index.jsp?main=mypage/adminqnalist.jsp?currentPage=<%=endPage+1%>"
-    		style="color: black;">다음</a>
-    	</li>
-    <%}
-          }
-  %>
-  
-  </ul>
+  <% String pageUrl="mypage/adminqnalist.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
+  <% } %>
  
   
 </div>

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -250,41 +250,9 @@ font-size: 14px;
    int totalCount=dao.selectMyPageTotalCount(myid);
    int perPage=5; //한페이지당 보여질 글의 갯수
    int perBlock=10; //한블럭당 보여질 페이지 갯수
-   int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-   int startPage; //각블럭당 보여질 시작페이지
-   int endPage; //각블럭당 보여질 끝페이지
-   int currentPage;  //현재페이지
-   int totalPage; //총페이지수
-   int no; //각페이지당 출력할 시작번호 
-   
-   //현재페이지 읽는데 단 null일경우는 1페이지로 준다
-   if(request.getParameter("currentPage")==null)
-      currentPage=1;
-   else
-      currentPage=Integer.parseInt(request.getParameter("currentPage"));
-   
-   //총페이지수 구한다
-   //총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-   //나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-   totalPage=totalCount/perPage+(totalCount%perPage==0?0:1);
-   
-   //각블럭당 보여질 시작페이지
-   //perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-   //현재가 13일경우 시작:11 끝:15
-   startPage=(currentPage-1)/perBlock*perBlock+1;
-   endPage=startPage+perBlock-1;
-   
-   //총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-   if(endPage>totalPage)
-      endPage=totalPage;
-   
-   //각페이지에서 보여질 시작번호
-   //1페이지:0, 2페이지:5 3페이지: 10.....
-   startNum=(currentPage-1)*perPage;
-   
-   //각페이지당 출력할 시작번호 구하기
-   //총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-   no=totalCount-(currentPage-1)*perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
    
    //페이지에서 보여질 글만 가져오기
    List<QaDto> list = dao.selectMyPageList(startNum, perPage, myid);
@@ -379,42 +347,9 @@ font-size: 14px;
    <div id="pagelayout">
 
   <!-- 페이지 번호 출력 -->
-  <ul class="pagination justify-content-center">
-  <%
-  //이전
-  if(startPage>1)
-  {%>
-     <li class="page-item ">
-      <a class="page-link" href="index.jsp?main=mypage/myqnalist.jsp?currentPage=<%=startPage-1%>" style="color: black;">이전</a>
-     </li>
-  <%}
-    for(int pp=startPage;pp<=endPage;pp++)
-    {
-       if(pp==currentPage)
-       {%>
-          <li class="page-item active">
-          <a class="page-link" href="index.jsp?main=mypage/myqnalist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-          </li>
-       <%}else
-       {%>
-          <li class="page-item">
-          <a class="page-link" href="index.jsp?main=mypage/myqnalist.jsp?currentPage=<%=pp%>"><%=pp %></a>
-          </li>
-       <%}
-    }
-    
-    //다음
-    if(endPage<totalPage)
-    {%>
-       <li class="page-item">
-          <a  class="page-link" href="index.jsp?main=mypage/myqnalist.jsp?currentPage=<%=endPage+1%>"
-          style="color: black;">다음</a>
-       </li>
-    <%}
-          }
-  %>
-  
-  </ul>
+  <% String pageUrl="mypage/myqnalist.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
+  <% } %>
  
   
 </div>

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -194,12 +194,6 @@ font-size: 14px;
 </style>
 <script type="text/javascript">
    $(function(){
-      //메뉴탭기능 클릭하면 리뷰페이지로 이동
-      $("#next").click(function(){
-            location.href="index.jsp?main=mypage/myreviewlist.jsp";
-        });
-      
-      
        //전체체크 클릭시 체크값 얻어서 모든체크값 에 전달
         $(".alldelcheck").click(function(){
            
@@ -317,10 +311,8 @@ font-size: 14px;
 
 <div class="container">
 <div class="reviewlist">
-   <ul class="tabs">
-         <li id="first"><span style="font-size: 14px;">Q&A</span></li>
-         <li id="next"><span style="font-size: 14px;">REVIEW</span></li>
-   </ul>
+   <% String mypageTab="qa"; %>
+   <%@ include file="/layout/mypageTabs.jspf" %>
    <div id="tab2" class="tab2" style="margin-top: 40px;">
       <table class="table table-bordered">
          <tr style="height: 30px;">

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -255,41 +255,9 @@ ReviewDao dao = new ReviewDao();
 int totalCount = dao.selectMyPageTotalCount(myid);
 int perPage = 5; //한페이지당 보여질 글의 갯수
 int perBlock = 10; //한블럭당 보여질 페이지 갯수
-int startNum; //db에서 가져올 글의 시작번호(mysql은 첫글이0번,오라클은 1번);
-int startPage; //각블럭당 보여질 시작페이지
-int endPage; //각블럭당 보여질 끝페이지
-int currentPage; //현재페이지
-int totalPage; //총페이지수
-int no; //각페이지당 출력할 시작번호 
-
-//현재페이지 읽는데 단 null일경우는 1페이지로 준다
-if (request.getParameter("currentPage") == null)
-	currentPage = 1;
-else
-	currentPage = Integer.parseInt(request.getParameter("currentPage"));
-
-//총페이지수 구한다
-//총글갯수/한페이지당보여질갯수로 나눔(7/5=1)
-//나머지가 1이라도 있으면 무조건 1페이지 추가(1+1=2페이지가 필요)
-totalPage = totalCount / perPage + (totalCount % perPage == 0 ? 0 : 1);
-
-//각블럭당 보여질 시작페이지
-//perBlock=5일경우 현재페이지가 1~5일경우 시작페이지가1,끝페이지가 5
-//현재가 13일경우 시작:11 끝:15
-startPage = (currentPage - 1) / perBlock * perBlock + 1;
-endPage = startPage + perBlock - 1;
-
-//총페이지가 23일경우 마지막블럭은 끝페이지가 25가 아니라 23
-if (endPage > totalPage)
-	endPage = totalPage;
-
-//각페이지에서 보여질 시작번호
-//1페이지:0, 2페이지:5 3페이지: 10.....
-startNum = (currentPage - 1) * perPage;
-
-//각페이지당 출력할 시작번호 구하기
-//총글개수가 23  , 1페이지:23 2페이지:18  3페이지:13
-no = totalCount - (currentPage - 1) * perPage;
+%>
+<%@ include file="/layout/pagingCalc.jspf" %>
+<%
 
 //페이지에서 보여질 글만 가져오기
 List<ReviewDto> list = dao.selectMyPageList(startNum, perPage, myid);
@@ -381,44 +349,9 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 			<div id="pagelayout">
 
 				<!-- 페이지 번호 출력 -->
-				<ul class="pagination justify-content-center">
-					<%
-					//이전
-					if (startPage > 1) {
-					%>
-					<li class="page-item "><a class="page-link"
-						href="index.jsp?main=mypage/myreviewlist.jsp?currentPage=<%=startPage - 1%>"
-						style="color: black;">이전</a></li>
-					<%
-					}
-					for (int pp = startPage; pp <= endPage; pp++) {
-					if (pp == currentPage) {
-					%>
-					<li class="page-item active"><a class="page-link"
-						href="index.jsp?main=mypage/myreviewlist.jsp?currentPage=<%=pp%>"><%=pp%></a>
-					</li>
-					<%
-					} else {
-					%>
-					<li class="page-item"><a class="page-link"
-						href="index.jsp?main=mypage/myreviewlist.jsp?currentPage=<%=pp%>"><%=pp%></a>
-					</li>
-					<%
-					}
-					}
-
-					//다음
-					if (endPage < totalPage) {
-					%>
-					<li class="page-item"><a class="page-link"
-						href="index.jsp?main=mypage/myreviewlist.jsp?currentPage=<%=endPage + 1%>"
-						style="color: black;">다음</a></li>
-					<%
-					}
-					}
-					%>
-
-				</ul>
+				<% String pageUrl="mypage/myreviewlist.jsp"; String pageQuery=""; %>
+<%@ include file="/layout/pagingNav.jspf" %>
+				<% } %>
 
 
 			</div>

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -197,12 +197,7 @@ div.img-container{
 
 </style>
 <script type="text/javascript">
-	$(function(){		
-		//메뉴탭기능 클릭하면 QnA페이지로 이동
-		$("#first").click(function(){
-            location.href="index.jsp?main=mypage/myqnalist.jsp";
-        });
-		
+	$(function(){
 		 //전체체크 클릭시 체크값 얻어서 모든체크값 에 전달
 		  $(".alldelcheck").click(function(){
 			  
@@ -322,10 +317,8 @@ SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 
 	<div class="container">
 		<div class="reviewlist">
-			<ul class="tabs">
-				<li id="first"><span style="font-size: 14px;">Q&A</span></li>
-				<li id="next"><span style="font-size: 14px;">REVIEW</span></li>
-			</ul>
+			<% String mypageTab="review"; %>
+			<%@ include file="/layout/mypageTabs.jspf" %>
 			<div id="tab2" class="tab2" style="margin-top: 40px;">
      		 <table class="table table-bordered">
         			 <tr style="height: 30px;">


### PR DESCRIPTION
## 개요
2단계(코드 컨벤션·유지보수성) 로드맵의 일환. 마이페이지 목록 5종에 복붙돼
있던 **탭 네비게이션 마크업/전환 JS**와, #90에서 다루지 않은 **페이징
스크립틀릿**을 정적 `<%@ include %>` 프래그먼트로 추출했다. **동작 보존이
절대 원칙인 순수 리팩터**(기능 변경 0).

대상 5종: `mypage/{myqnalist, myreviewlist, adminqnalist, adminnoticelist, admineventlist}.jsp`

## 커밋 구성
1. **탭 UI/JS 공통 프래그먼트** — `layout/mypageTabs.jspf`(사용자 2탭 Q&A/REVIEW),
   `layout/mypageAdminTabs.jspf`(관리자 3탭 Q&A/NOTICE/EVENT) 신설 + 5종 적용.
   계약변수(`mypageTab`/`adminTab`)로 활성 탭을 받아 **비활성 탭에만** 클릭
   핸들러 등록 → 각 host가 만들던 핸들러 집합·이동 URL과 1:1 동일.
2. **페이징 공통 include** — 계산부→`pagingCalc.jspf`, 번호출력부→`pagingNav.jspf`
   (#90 산출물 그대로). perPage는 파일별 유지(adminqnalist=10, 나머지=5).

## 설계 메모
- 활성 탭 강조 CSS(id별 초록)는 각 host `<style>`에 그대로 둠 — CSS 공용 분리는
  다음 로드맵 항목 소관.
- 이 5종은 게시판 4종과 달리 표 본문이 `if(totalCount==0){}else{}`로 감싸여 있어
  **else 닫는 `}`가 옛 페이징 스크립틀릿 안에 박혀** 있었다. 이를 pagingNav include
  뒤 `<% } %>`로 옮겨 "글 있을 때만 페이징 렌더" 의도를 보존. 글 0건일 때 옛 코드가
  내보내던 **고아 `</ul>`**(여는 태그 없는 닫기)가 사라지는 것이 유일한 차이이며
  관측 불가(오히려 마크업 정상화).
- 기존 잠재 결함은 의도적으로 **미수정 보존**: myreviewlist 빈페이지 redirect의
  `myreviewList.jsp`(대문자 L) 오타, admineventlist 행 링크가 `noticeDetail.jsp?...&n_num=<E_num>`인 점.

## 검증 (full rigor, 매 커밋)
- **JspC 게이트 EXIT=0** (122 JSP translate+compile, 0 errors) — 두 커밋 모두.
- **`git diff -w`**: 들여쓰기 외 의도치 않은 토큰 변경 0.
- **/simplify + /code-review(high)**: 라인스캔·removed-behavior·cross-file/scope 각도
  모두 0건. 중괄호 균형, 변수 이중선언/누락, 핸들러 집합·pageUrl 정합성 확인.

## ⚠ JSP 런타임 스모크 체크리스트 (IntelliJ + Tomcat에서 수행 필요)
JspC는 변환·컴파일·시그니처만 잡고 런타임(redirect 대상·세션·CSS 시각·JS 동작)은
못 잡으므로 아래를 실제 구동으로 확인:

- [ ] **사용자 탭**: 내 문의 ↔ 내 후기 상호 전환 클릭, 활성 탭 초록 강조, 각 목록/페이징/삭제 정상.
- [ ] **관리자 탭**: Q&A ↔ NOTICE ↔ EVENT 3탭 상호 전환, 활성 표시, 각 목록/페이징/일괄삭제 정상.
- [ ] **페이징**: 이전/다음/번호 이동(adminqnalist는 perPage=10), 빈페이지 redirect(마지막 글 삭제 시 이전 페이지).
- [ ] **비로그인/권한 가드** 동작 불변.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
