### PR TITLE
refactor(css): 페이지네이션 공통 스타일 외부 .css 분리 (목록 9종)

### DIFF
--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -19,6 +19,7 @@
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>HUEAT</title>
 
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -99,19 +100,6 @@ color: #0897B4;
 
 a:active{
 color: black;
-}
-
-.pagination .page-item.active .page-link {
-    background-color: #618E6E;
-    border-color: #618E6E;
-}
-
-.pagination .page-item .page-link:hover {
-    color: #618E6E;
-}
-
-.pagination .page-item.active .page-link:hover {
-    color: white;
 }
 
 #searcharea{

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -18,6 +18,7 @@
 
 <title>HUEAT</title>
 
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -54,19 +55,6 @@ a:hover{
 
 a:active{
 	color: black;
-}
-
-.pagination .page-item.active .page-link {
-    background-color: #618E6E;
-    border-color: #618E6E;
-}
-
-.pagination .page-item .page-link:hover {
-    color: #618E6E;
-}
-
-.pagination .page-item.active .page-link:hover {
-    color: white;
 }
 
 #searcharea{

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -18,6 +18,7 @@
 
 <title>HUEAT</title>
 
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -54,19 +55,6 @@ a:hover{
 
 a:active{
 	color: black;
-}
-
-.pagination .page-item.active .page-link {
-    background-color: #618E6E;
-    border-color: #618E6E;
-}
-
-.pagination .page-item .page-link:hover {
-    color: #618E6E;
-}
-
-.pagination .page-item.active .page-link:hover {
-    color: white;
 }
 
 #searcharea{

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -19,6 +19,7 @@
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>HUEAT</title>
 
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -104,19 +105,6 @@ color: #0897B4;
 
 a:active{
 color: black;
-}
-
-.pagination .page-item.active .page-link {
-    background-color: #618E6E;
-    border-color: #618E6E;
-}
-
-.pagination .page-item .page-link:hover {
-    color: #618E6E;
-}
-
-.pagination .page-item.active .page-link:hover {
-    color: white;
 }
 
 #searcharea{

--- a/src/main/webapp/layout/pagination.css
+++ b/src/main/webapp/layout/pagination.css
@@ -1,0 +1,17 @@
+/* 페이지네이션 공통 스타일 (목록 페이지 공용).
+   여러 목록 JSP의 <style>에 바이트 동일하게 복붙돼 있던 .pagination 3규칙을 추출.
+   각 페이지 <head>에서 <link href="layout/pagination.css">로 로드한다.
+   활성 페이지 강조색(#618E6E)과 hover 색만 정의하며, 그 외(.page-link 기본색 등)는
+   Bootstrap 기본값을 따른다. */
+.pagination .page-item.active .page-link {
+    background-color: #618E6E;
+    border-color: #618E6E;
+}
+
+.pagination .page-item .page-link:hover {
+    color: #618E6E;
+}
+
+.pagination .page-item.active .page-link:hover {
+    color: white;
+}

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -14,6 +14,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>이벤트 관리</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -166,19 +167,6 @@ font-size: 14px;
 		position: relative;
 
 }
-	.pagination .page-item.active .page-link {
-	    background-color: #618E6E;
-	    border-color: #618E6E;
-	}
-	
-	.pagination .page-item .page-link:hover {
-	    color: #618E6E;
-	}
-	
-	.pagination .page-item.active .page-link:hover {
-	    color: white;
-	}
-	
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -14,6 +14,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>공지 관리</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -167,19 +168,6 @@ font-size: 14px;
 		position: relative;
 
 }
-	.pagination .page-item.active .page-link {
-	    background-color: #618E6E;
-	    border-color: #618E6E;
-	}
-	
-	.pagination .page-item .page-link:hover {
-	    color: #618E6E;
-	}
-	
-	.pagination .page-item.active .page-link:hover {
-	    color: white;
-	}
-	
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -14,6 +14,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>관리자 QnA 답변 목록</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -164,19 +165,6 @@ font-size: 14px;
 		position: relative;
 
 }
-	.pagination .page-item.active .page-link {
-	    background-color: #618E6E;
-	    border-color: #618E6E;
-	}
-	
-	.pagination .page-item .page-link:hover {
-	    color: #618E6E;
-	}
-	
-	.pagination .page-item.active .page-link:hover {
-	    color: white;
-	}
-	
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -16,6 +16,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>내 문의 목록</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 ul.tabs {
    margin: 0px;
@@ -167,19 +168,6 @@ font-size: 14px;
 
 }
 
-	.pagination .page-item.active .page-link {
-	    background-color: #618E6E;
-	    border-color: #618E6E;
-	}
-	
-	.pagination .page-item .page-link:hover {
-	    color: #618E6E;
-	}
-	
-	.pagination .page-item.active .page-link:hover {
-	    color: white;
-	}
-	
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -19,6 +19,7 @@
 	href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>내 후기</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -169,19 +170,6 @@ div.img-container{
 
 }
 
-	.pagination .page-item.active .page-link {
-	    background-color: #618E6E;
-	    border-color: #618E6E;
-	}
-	
-	.pagination .page-item .page-link:hover {
-	    color: #618E6E;
-	}
-	
-	.pagination .page-item.active .page-link:hover {
-	    color: white;
-	}
-	
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;


### PR DESCRIPTION
## 개요
2단계 로드맵의 **공용 CSS 분리** 첫 슬라이스. 목록 페이지들에 바이트 동일하게
복붙돼 있던 `.pagination` 3규칙을 외부 공용 스타일시트로 추출했다. **순수
리팩터(시각 결과 보존)**.

## 변경
- 신설 `layout/pagination.css`: active 강조(#618E6E)·hover 색 3규칙.
- **적용 9종**(인라인 블록이 바이트 동일한 변형만): `hugesoinfo/{hugesolist, hugesolist2, hugesolist2search, hugesolistsearch}.jsp`, `mypage/{myqnalist, myreviewlist, adminqnalist, adminnoticelist, admineventlist}.jsp`
- 각 `<head>` 인라인 `<style>`에서 3규칙 제거 + 앞에 `<link href="layout/pagination.css">` 추가.

## 설계 메모
- **메커니즘**: 페이지별 `<link>` opt-in(전역 link 아님 — 53개 파일 specificity 충돌 회피).
  기존 `hugesodetail.css`와 동일한 context-상대경로 방식.
- **캐스케이드 보존**: link를 Bootstrap 뒤·인라인 `<style>` 앞에 배치. `info.jsp`가
  main 페이지 뒤에서 Bootstrap을 재로딩하지만, pagination 셀렉터 명시도(0,4,0)가
  Bootstrap(0,2,0)을 이겨 결과 불변(추출 전 인라인과 동일).
- **범위 외(다음 슬라이스)**: 게시판 4종+hugesomap은 `.page-link` 기본색 2규칙이 더
  붙은 **별도 변형**이라 제외. banner(`img-container`/`span-container` 17종)·table·
  활성탭 강조 CSS도 별도 슬라이스로 분리 예정.

## 검증
- **JspC 게이트 EXIT=0** (122 JSP).
- **/code-review(high)**: 캐스케이드·명시도 / href 정합성 / 제거 완전성 3각도 **0건**.
- ⚠ **CSS는 자동 시각 게이트가 없음** → 아래 IntelliJ 확인 필수.

## ⚠ IntelliJ + Tomcat 시각 스모크 체크리스트
- [ ] 휴게소 목록 4종(목록형/앨범형 × 전체/검색): 페이지네이션 **활성 페이지 초록(#618E6E) 강조**·hover 색 정상.
- [ ] 마이페이지 5종(내 문의/후기, 관리자 Q&A/NOTICE/EVENT): 페이지네이션 활성/hover 동일.
- [ ] 브라우저 개발자도구 Network에서 `layout/pagination.css` **200 OK**(404 아님) 확인.
- [ ] 미적용 5종(eventList/noticeList/qaList/reviewList/hugesomap)은 기존 인라인 그대로라 변화 없음 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
