### PR TITLE
css: 페이지네이션 변형B 공통 스타일 외부 .css로 분리 (목록 5종)

### DIFF
--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -16,6 +16,7 @@
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>이벤트</title>
 
+<link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
  <style type="text/css">
 
   button.col {
@@ -91,29 +92,9 @@
 		width: 70%;
 		display: block;
 	}
-		.pagination .page-item.active .page-link {
-    		background-color: #618E6E;
-    		border-color: #618E6E;
-		}
-		
-		.pagination .page-item .page-link{
-			color: black;
-		}
-		
-		.pagination .page-item.active .page-link{
-			color: white;
-		}
-		
-		.pagination .page-item .page-link:hover {
-		    color: #618E6E;
-		}
-		
-		.pagination .page-item.active .page-link:hover {
-		    color: white;
-		}
-	
-  
-  
+
+
+
 </style>
 
 </head>

--- a/src/main/webapp/hugesoinfo/hugesomap.jsp
+++ b/src/main/webapp/hugesoinfo/hugesomap.jsp
@@ -13,6 +13,7 @@
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 	<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=b71304786948cbe7995d40be3007bd8e"></script>
 <title>휴게소 찾기</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 	<style type="text/css">
 		#area{
 			margin-top: 7%;
@@ -94,27 +95,6 @@
 		
 		ul{
 			cursor: pointer;
-		}
-		
-		.pagination .page-item.active .page-link {
-    		background-color: #618E6E;
-    		border-color: #618E6E;
-		}
-		
-		.pagination .page-item .page-link{
-			color: black;
-		}
-		
-		.pagination .page-item.active .page-link{
-			color: white;
-		}
-		
-		.pagination .page-item .page-link:hover {
-		    color: #618E6E;
-		}
-		
-		.pagination .page-item.active .page-link:hover {
-		    color: white;
 		}
 
 

--- a/src/main/webapp/layout/pagination-b.css
+++ b/src/main/webapp/layout/pagination-b.css
@@ -1,0 +1,25 @@
+/* 페이지네이션 공통 스타일 — 변형B (게시판 4종 + 휴게소 지도 공용).
+   슬라이스1 pagination.css의 3규칙에 .page-link 글자색(black)·활성 글자색(white)
+   2규칙이 더 붙은 상위집합. 변형B를 쓰는 5종이 인라인 <style>에 바이트 동일하게
+   복붙하던 것을 추출. 각 페이지 <head>에서 <link href="layout/pagination-b.css">로 로드.
+   캐스케이드 보존을 위해 인라인에 있던 규칙 순서를 그대로 유지한다. */
+.pagination .page-item.active .page-link {
+    background-color: #618E6E;
+    border-color: #618E6E;
+}
+
+.pagination .page-item .page-link {
+    color: black;
+}
+
+.pagination .page-item.active .page-link {
+    color: white;
+}
+
+.pagination .page-item .page-link:hover {
+    color: #618E6E;
+}
+
+.pagination .page-item.active .page-link:hover {
+    color: white;
+}

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -15,6 +15,7 @@
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>공지사항</title>
 
+<link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <style type="text/css">
 
   button.col {
@@ -91,28 +92,6 @@
 		width: 70%;
 		display: block;
 	}
-
-		.pagination .page-item.active .page-link {
-    		background-color: #618E6E;
-    		border-color: #618E6E;
-		}
-		
-		.pagination .page-item .page-link{
-			color: black;
-		}
-		
-		.pagination .page-item.active .page-link{
-			color: white;
-		}
-		
-		.pagination .page-item .page-link:hover {
-		    color: #618E6E;
-		}
-		
-		.pagination .page-item.active .page-link:hover {
-		    color: white;
-		}
-	
 
 </style>
 

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -15,6 +15,7 @@
     <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>QnA 게시판</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <style type="text/css">
 
   button.col {
@@ -89,29 +90,7 @@
  	div.tablediv th{
   	background-color: #DFE8E2;
   }
-  
-  	.pagination .page-item.active .page-link {
-    		background-color: #618E6E;
-    		border-color: #618E6E;
-		}
-		
-		.pagination .page-item .page-link{
-			color: black;
-		}
-		
-		.pagination .page-item.active .page-link{
-			color: white;
-		}
-		
-		.pagination .page-item .page-link:hover {
-		    color: #618E6E;
-		}
-		
-		.pagination .page-item.active .page-link:hover {
-		    color: white;
-		}
-	
-  
+
 </style>
 
 </head>

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>후기게시판</title>
+<link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <style type="text/css">
 
   span.day{
@@ -74,27 +75,6 @@
 		font-size: 3em;
 }
 
-		.pagination .page-item.active .page-link {
-    		background-color: #618E6E;
-    		border-color: #618E6E;
-		}
-		
-		.pagination .page-item .page-link{
-			color: black;
-		}
-		
-		.pagination .page-item.active .page-link{
-			color: white;
-		}
-		
-		.pagination .page-item .page-link:hover {
-		    color: #618E6E;
-		}
-		
-		.pagination .page-item.active .page-link:hover {
-		    color: white;
-		}
-  
 </style>
 
 


### PR DESCRIPTION
## 개요
2단계 리팩터링 **CSS 분리 슬라이스2**. 여러 목록 JSP의 인라인 `<style>`에 바이트 동일하게 복붙돼 있던 `.pagination` 규칙을 공용 외부 `.css`로 추출하는 작업의 두 번째 묶음이다.

- 슬라이스1(PR #92): `.pagination` **3규칙**(active 배경 #618E6E·hover) → `layout/pagination.css`, 9종 적용.
- 슬라이스2(이번 PR): 그 3규칙에 `.page-link{color:black}` + `active .page-link{color:white}` **2규칙**이 더 붙은 상위집합(**5규칙 변형B**)을 쓰는 5종 처리.

## 변경
- **신설** `layout/pagination-b.css` — 변형B 5규칙(인라인에 있던 순서 그대로 보존). 슬라이스1 `pagination.css`와 독립(재사용하지 않음, 방식 A).
- **5종 edit** — 인라인 `.pagination` 5규칙 블록 삭제 + Bootstrap link 뒤·인라인 `<style>` 앞에 `<link href="layout/pagination-b.css">` 추가.
  - `eventboard/eventList.jsp`
  - `noticeboard/noticeList.jsp`
  - `qaboard/qaList.jsp`
  - `reviewboard/reviewList.jsp`
  - `hugesoinfo/hugesomap.jsp`

## 동일성·캐스케이드
- 5종 모두 5규칙의 **순서·값이 동일**함을 확인(들여쓰기 공백만 상이 — CSS상 무의미). 제외·분리 대상 없음.
- hugesomap은 페이징이 클라이언트 JS(AJAX)지만 `.pagination` **CSS 규칙 자체는 5종과 동일** → 포함 타당.
- 규칙 명시도(0,3,0~0,5,0) > Bootstrap pagination 기본(0,2,0)이라 `info.jsp`가 Bootstrap을 재로딩해도 결과 불변(슬라이스1과 동일 논리).
- `href`는 context-상대경로 — 모든 페이지가 `index.jsp?main=...`로 로드되어 document base가 context-root/index.jsp라 정상 해석(슬라이스1 검증 완료).

## 검증
- ✅ **JspC**: `scripts/jspc-check.ps1` → 122 JSP 변환+컴파일, 0 오류(EXIT=0).
- ✅ **/code-review high**: 캐스케이드 보존·href 해석·인라인 제거 완전성 각도 — 버그 0건.
- ⚠️ **CSS는 자동 게이트 없음 → IntelliJ+Tomcat 시각 스모크 필요**(아래 체크리스트).

## 시각 스모크 체크리스트 (리뷰어)
`index.jsp?main=...`로 5종 진입(이벤트/공지/QnA/후기 목록 + 휴게소 지도) 후 페이지네이션 영역에서:
- [ ] 비활성 페이지 번호 글자색 = **검정**
- [ ] 활성 페이지: 배경/테두리 = **#618E6E(녹색)**, 글자색 = **흰색**
- [ ] hover: 비활성 글자색 = **녹색(#618E6E)**, 활성 글자색 = **흰색 유지**
- [ ] 분리 전 대비 시각 차이 없음
- [ ] hugesomap은 AJAX 목록 로딩 후 페이지 번호가 위와 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)