### PR TITLE
css: 배너 공통 스타일(img-container/span-container 3규칙) 외부 .css로 분리 (목록 17종)

### DIFF
--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -17,6 +17,7 @@
 <title>이벤트</title>
 
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
  <style type="text/css">
 
   button.col {
@@ -35,34 +36,6 @@
     color: black;
   
   }
-   div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
-
 	div.span-container span{
 		z-index: 9999;
 		color: white;

--- a/src/main/webapp/foodcourt/choicehuegeso.jsp
+++ b/src/main/webapp/foodcourt/choicehuegeso.jsp
@@ -11,6 +11,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Grandiflora+One&family=Gugi&family=Hahmlet:wght@100..900&family=Hi+Melody&family=Sunflower:wght@300&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>휴게소 선택</title>
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style>
 	#all{
 		margin:0 auto;
@@ -48,34 +49,6 @@
   input::placeholder {
   	color: white;
 	}
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
-
 	div.span-container span{
 		z-index: 999;
 		color: white;

--- a/src/main/webapp/foodcourt/foodmenu.jsp
+++ b/src/main/webapp/foodcourt/foodmenu.jsp
@@ -19,6 +19,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Grandiflora+One&family=Gugi&family=Hahmlet:wght@100..900&family=Hi+Melody&family=Sunflower:wght@300&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>푸드코트 메뉴</title>
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 #container {
   margin: 0 auto; 
@@ -79,34 +80,6 @@ div.img{
   align-items: center; /* 요소들을 수평 가운데로 정렬합니다. */
   margin-bottom: 20px; /* 필요에 따라 여백을 조정합니다. */
 }
-
-div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 999;

--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -20,6 +20,7 @@
 <title>HUEAT</title>
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -115,34 +116,6 @@ color: black;
 #searcharea button{
 	background-color: #618E6E;
 }
-
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 999;

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -19,6 +19,7 @@
 <title>HUEAT</title>
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -72,34 +73,6 @@ a:active{
 }
 
 
-
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/hugesoinfo/hugesomap.jsp
+++ b/src/main/webapp/hugesoinfo/hugesomap.jsp
@@ -14,6 +14,7 @@
 	<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=b71304786948cbe7995d40be3007bd8e"></script>
 <title>휴게소 찾기</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 	<style type="text/css">
 		#area{
 			margin-top: 7%;
@@ -97,34 +98,6 @@
 			cursor: pointer;
 		}
 
-
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/layout/banner.css
+++ b/src/main/webapp/layout/banner.css
@@ -1,0 +1,32 @@
+@charset "UTF-8";
+/* 배너 영역 공통 스타일 (목록 페이지 공용).
+   여러 목록 JSP의 <style>에 바이트 동일하게 복붙돼 있던 배너 3규칙
+   (div.img-container / div.img-container img / div.span-container)을 추출.
+   각 페이지 <head>에서 <link href="layout/banner.css">로 로드한다.
+   ※ 4번째 규칙 div.span-container span은 페이지마다 z-index·font-size·속성순서가
+      달라(6분기) 공통화하지 못하므로 각 host 인라인 <style>에 그대로 남겨둔다. */
+div.img-container {
+	width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
+	height: 250px; /* 원하는 높이로 설정 */
+	overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
+	border: 0px solid black;
+	background-position: top;
+	text-align: center;
+}
+div.img-container img {
+	top: 0;
+	width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
+	height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
+	object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
+}
+div.span-container {
+	width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
+	height: 250px; /* 원하는 높이로 설정 */
+	overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
+	background-position: top;
+	margin-top: -14%;
+	text-align: center;
+	display: flex;
+	justify-content: center; /* 수평 가운데 정렬 */
+	align-items: center; /* 수직 가운데 정렬 */
+}

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -15,6 +15,7 @@
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>이벤트 관리</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -132,34 +133,6 @@ font-size: 14px;
 	color: #b4a8a8;
 	}
 
-
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -15,6 +15,7 @@
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>공지 관리</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -133,34 +134,6 @@ font-size: 14px;
 	color: #b4a8a8;
 	}
 
-
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -15,6 +15,7 @@
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>관리자 QnA 답변 목록</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -130,34 +131,6 @@ font-size: 14px;
 	color: #b4a8a8;
 	}
 
-
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/mypage/favlist.jsp
+++ b/src/main/webapp/mypage/favlist.jsp
@@ -11,6 +11,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Grandiflora+One&family=Gugi&family=Hahmlet:wght@100..900&family=Hi+Melody&family=Sunflower:wght@300&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>즐겨찾기 목록</title>
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 	button{
 		background-color: #618E6E;
@@ -20,34 +21,6 @@
 		width: 100px;
 	}
 	
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
-
 	div.span-container span{
 		z-index: 9999;
 		color: white;

--- a/src/main/webapp/mypage/memberlist.jsp
+++ b/src/main/webapp/mypage/memberlist.jsp
@@ -18,6 +18,7 @@ if(!util.SecurityUtil.isAdmin(session)){
 <link href="https://fonts.googleapis.com/css2?family=Grandiflora+One&family=Gugi&family=Hahmlet:wght@100..900&family=Hi+Melody&family=Sunflower:wght@300&display=swap" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>회원 목록</title>
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 
    button.search{
@@ -40,35 +41,6 @@ if(!util.SecurityUtil.isAdmin(session)){
    }
 
    
-      div.img-container{
-
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-     border: 0px solid black;
-     background-position: top;
-     text-align: center;
-}
-   
-   div.img-container img {
-      top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-   div.span-container{
-      width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-     background-position: top;
-      margin-top:-14%;
-     text-align: center;
-     display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-   }
-
    div.span-container span{
       z-index: 9999;
       color: white;

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -17,6 +17,7 @@
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>내 문의 목록</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 ul.tabs {
    margin: 0px;
@@ -132,34 +133,6 @@ font-size: 14px;
 	font-size: 12px;
 	color: #b4a8a8;
 	}
-
-   div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-     border: 0px solid black;
-     background-position: top;
-     text-align: center;
-}
-   
-   div.img-container img {
-      top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-   div.span-container{
-      width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-     background-position: top;
-      margin-top:-14%;
-     text-align: center;
-     display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-   }
 
    div.span-container span{
       z-index: 9999;

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -20,6 +20,7 @@
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>내 후기</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -133,34 +134,6 @@ font-size: 14px;
 .table-bordered	td.day {
 	font-size: 12px;
 	color: #b4a8a8;
-	}
-
-div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
 	}
 
 	div.span-container span{

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -16,6 +16,7 @@
 <title>공지사항</title>
 
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 
   button.col {
@@ -35,34 +36,6 @@
   
   }
   
-  	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
-
 	div.span-container span{
 		z-index: 9999;
 		color: white;

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -16,6 +16,7 @@
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>QnA 게시판</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 
   button.col {
@@ -30,34 +31,6 @@
   
   }
    
-  div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
-
 	div.span-container span{
 		z-index: 999;
 		color: white;

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -15,6 +15,7 @@
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>후기게시판</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
 
   span.day{
@@ -40,34 +41,6 @@
   }
   
     
-   div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
-
 	div.span-container span{
 		z-index: 9999;
 		color: white;

--- a/src/main/webapp/shop/shopList.jsp
+++ b/src/main/webapp/shop/shopList.jsp
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>쇼핑몰</title>
+<link rel="stylesheet" type="text/css" href="layout/banner.css">
 <style type="text/css">
   .s_list {
   width: 100%;
@@ -50,34 +51,6 @@
   .nav-link:hover{
   color: green!important; 
   }
-
-	div.img-container{
-    width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	border: 0px solid black;
-  	background-position: top;
-  	text-align: center;
-}
-	
-	div.img-container img {
-		top: 0;
-    width: 100%; /* 이미지가 부모 요소의 가로폭을 다 차지하도록 설정 */
-    height: auto; /* 세로 비율을 유지하기 위해 자동으로 조정 */
-    object-fit: cover; /* 이미지를 부모 요소에 맞게 잘라내어 배치 */
-    
-}
-	div.span-container{
-		width: 100%; /* 이미지를 감싸는 부모 요소의 가로폭 */
-    height: 250px; /* 원하는 높이로 설정 */
-    overflow: hidden; /* 내용이 넘칠 경우를 대비하여 오버플로우를 숨김으로 설정 */
-  	background-position: top;
-		margin-top:-14%;
-  	text-align: center;
-  	display: flex;
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
-	}
 
 	div.span-container span{
 		z-index: 999;


### PR DESCRIPTION
## 배경
2단계 리팩터링 CSS 슬라이스 작업. 여러 목록 JSP의 인라인 `<style>`에 **바이트 동일하게 복붙**된 배너 CSS를 공용 외부 `.css`로 추출(dedup)한다. 슬라이스1(`layout/pagination.css`, 9종)·슬라이스2(`layout/pagination-b.css`, 5종)와 동일 메커니즘.

## 변경 내용
배너 블록 4규칙 중 **앞 3규칙**(`div.img-container` / `div.img-container img` / `div.span-container`)은 17종 전부 속성 동일(들여쓰기만 상이) → 신설 `layout/banner.css`로 추출하고, 각 host는 인라인 3규칙 삭제 + `<link href="layout/banner.css">`(Bootstrap 뒤·인라인 `<style>` 앞)로 로드.

**4번째 규칙** `div.span-container span`은 페이지마다 `z-index`(999/9999)·`font-size` 유무·속성순서가 달라(**6분기**) 공통화 불가 → 각 host 인라인에 그대로 잔류(공통 추출 + 그룹별 잔류 방식).

### 적용 17종
`hugesolist` · `hugesolist2` · `hugesomap` · `reviewList` · `noticeList` · `qaList` · `eventList` · `shopList` · `foodmenu` · `choicehuegeso` · `favlist` · `memberlist` · `myqnalist` · `myreviewlist` · `adminqnalist` · `adminnoticelist` · `admineventlist`

## 동작 보존 근거
- **시각 변화 0**: 17종 각 삭제분을 공백 무시 비교 시 `banner.css` 3규칙과 **완전 동일**(오병합 0).
- **캐스케이드 불변**: banner 셀렉터 명시도 0,1,1 → Bootstrap(.table 0,2,0 등)과 교집합 없음. info.jsp Bootstrap 재로딩에도 결과 동일.
- `href`는 context-상대(`layout/banner.css`) — 17종 모두 `index.jsp?main=…` 경유라 정상 해석(슬라이스1/2 선례).

## 검증
- **JspC**: `scripts/jspc-check.ps1` → 122 JSP 변환+컴파일, **0 errors (exit 0)**
- **오병합 검증**: 17종 삭제 CSS = `banner.css` 3규칙 정규화 동일 (896바이트)
- **/code-review high**: 발견 0건
- ⚠ **사용자 IntelliJ+Tomcat 시각 스모크 대기**: 17종 배너 영역(이미지 250px·overflow 잘림·span 중앙정렬·margin-top -14%) 변화 없음 확인. 특히 link 메커니즘 첫 적용 5종(shopList·foodmenu·choicehuegeso·favlist·memberlist)에서 `banner.css` 정상 로드(404 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)