### PR TITLE
css: 마이페이지 목록 공통 스타일(#pagelayout·table.table) 외부 .css로 분리 (목록 5종)

### DIFF
--- a/src/main/webapp/layout/mypage-list.css
+++ b/src/main/webapp/layout/mypage-list.css
@@ -1,0 +1,25 @@
+@charset "UTF-8";
+/* 마이페이지 목록 공통 스타일 (admin·my 목록 5종 공용).
+   admineventlist/adminnoticelist/adminqnalist/myqnalist/myreviewlist의 <style>에
+   바이트 동일하게 복붙돼 있던 #pagelayout 1블록 + table.table 3규칙을 추출.
+   각 페이지 <head>에서 <link href="layout/mypage-list.css">로 로드한다. */
+#pagelayout {
+	text-align: center;
+	margin-left: auto;
+	margin-right: auto;
+	margin-top: -60px;
+}
+
+table.table {
+	margin-bottom: 80px;
+}
+
+table.table th, table.table td {
+	text-align: center; /* 가운데 정렬 */
+	vertical-align: middle; /* 수직 정렬 */
+}
+
+.table th, .table td {
+	padding: 8px; /* 셀의 안쪽 여백을 추가합니다 */
+	text-align: center; /* 셀의 텍스트를 가운데 정렬합니다 */
+}

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -16,6 +16,7 @@
 <title>이벤트 관리</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -98,26 +99,6 @@ div.container {
 	margin-right: auto;
 	margin-bottom: 50px;
 	margin-top: 128px;
-}
-
-#pagelayout {
-	text-align: center;
-	margin-left: auto;
-	margin-right: auto;
-	margin-top: -60px;
-}
-
-table.table {
-	margin-bottom: 80px;
-}
-
-table.table th, table.table td {
-	text-align: center; /* 가운데 정렬 */
-	vertical-align: middle; /* 수직 정렬 */
-}
-.table th, .table td {
-	padding: 8px; /* 셀의 안쪽 여백을 추가합니다 */
-	text-align: center; /* 셀의 텍스트를 가운데 정렬합니다 */
 }
 
 input[type="checkbox"] {

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -16,6 +16,7 @@
 <title>공지 관리</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -99,26 +100,6 @@ div.container {
 	margin-right: auto;
 	margin-bottom: 50px;
 	margin-top: 128px;
-}
-
-#pagelayout {
-	text-align: center;
-	margin-left: auto;
-	margin-right: auto;
-	margin-top: -60px;
-}
-
-table.table {
-	margin-bottom: 80px;
-}
-
-table.table th, table.table td {
-	text-align: center; /* 가운데 정렬 */
-	vertical-align: middle; /* 수직 정렬 */
-}
-.table th, .table td {
-	padding: 8px; /* 셀의 안쪽 여백을 추가합니다 */
-	text-align: center; /* 셀의 텍스트를 가운데 정렬합니다 */
 }
 
 input[type="checkbox"] {

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -16,6 +16,7 @@
 <title>관리자 QnA 답변 목록</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -95,27 +96,6 @@ div.container {
 	margin-right: auto;
 	margin-bottom: 50px;
 	margin-top: 128px;
-}
-
-#pagelayout {
-	text-align: center;
-	margin-left: auto;
-	margin-right: auto;
-	margin-top: -60px;
-}
-
-table.table {
-	margin-bottom: 80px;
-}
-
-table.table th, table.table td {
-	text-align: center; /* 가운데 정렬 */
-	vertical-align: middle; /* 수직 정렬 */
-}
-
-.table th, .table td {
-	padding: 8px; /* 셀의 안쪽 여백을 추가합니다 */
-	text-align: center; /* 셀의 텍스트를 가운데 정렬합니다 */
 }
 
 input[type="checkbox"] {

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -18,6 +18,7 @@
 <title>내 문의 목록</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <style type="text/css">
 ul.tabs {
    margin: 0px;
@@ -97,28 +98,6 @@ div.container {
    margin-right: auto;
    margin-bottom: 50px;
    margin-top: 128px;
-}
-
-#pagelayout {
-   text-align: center;
-   margin-left: auto;
-   margin-right: auto;
-   margin-top: -60px;
-}
-
-table.table {
-   margin-bottom: 80px;
-}
-
-table.table th, table.table td {
-   text-align: center; /* 가운데 정렬 */
-   vertical-align: middle; /* 수직 정렬 */
-}
-
-
-.table th, .table td {
-   padding: 8px; /* 셀의 안쪽 여백을 추가합니다 */
-   text-align: center; /* 셀의 텍스트를 가운데 정렬합니다 */
 }
 
 input[type="checkbox"] {

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -21,6 +21,7 @@
 <title>내 후기</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -100,27 +101,6 @@ div.container {
 	margin-right: auto;
 	margin-bottom: 50px;
 	margin-top: 128px;
-}
-
-#pagelayout {
-	text-align: center;
-	margin-left: auto;
-	margin-right: auto;
-	margin-top: -60px;
-}
-
-table.table {
-	margin-bottom: 80px;
-}
-
-table.table th, table.table td {
-	text-align: center; /* 가운데 정렬 */
-	vertical-align: middle; /* 수직 정렬 */
-}
-
-.table th, .table td {
-	padding: 8px; /* 셀의 안쪽 여백을 추가합니다 */
-	text-align: center; /* 셀의 텍스트를 가운데 정렬합니다 */
 }
 
 input[type="checkbox"] {


### PR DESCRIPTION
## 개요
여러 목록 JSP의 인라인 `<style>`에 바이트 동일하게 복붙된 CSS를 공용 외부 `.css`로 추출하는 CSS 슬라이스 작업의 연속(**슬라이스3++**). 선행: pagination(#92)·pagination-b(#93)·banner(#94).

mypage 목록 **5종**(`admineventlist`/`adminnoticelist`/`adminqnalist`/`myqnalist`/`myreviewlist`)에 동일하게 들어있던
- `#pagelayout` 1블록(`text-align:center` + `margin auto` + `margin-top:-60px`)
- `table.table` 3규칙(`margin-bottom:80px` / `table.table th,td` 정렬 / `.table th,td` 패딩·정렬)

을 신설 `layout/mypage-list.css`로 추출하고, 5종에서 인라인 블록 삭제 + `<link>` 1줄 추가(사용자 결정: 두 블록을 한 파일로).

## 순수 리팩터 (동작·시각 변화 0)
- `<link>` 위치는 **Bootstrap link 뒤·인라인 `<style>` 앞**(캐스케이드 보존), href는 context-상대경로.
- `.table th, .table td`(명시도 `0,2,0`)는 Bootstrap 셀 padding(`.table > :not(caption) > * > *`, `0,1,1`)보다 **명시도 우위**라 로드 순서 무관하게 적용. 인라인에 남는 `.table-bordered td.day`(`0,2,1`)도 원래부터 명시도로 이겨 소스 순서 영향 없음.

## 검증
- **오병합**: 5종 삭제 CSS = `mypage-list.css` 본문 공백무시 바이트 동일(스크립트 확인).
- **JspC 게이트**: 122 JSP translate+compile, 0 오류.
- **`/code-review high`**: findings 0건.
- numstat: 파일당 `+1`(link)/블록 삭제만, 줄끝 churn 없음.

## ⚠ 잔여 — IntelliJ + Tomcat 시각 스모크 대기
CSS는 자동 시각 게이트가 없어 사용자 확인 필요:
- 5종 페이지 로드 시 `layout/mypage-list.css` 200 OK 로드(Network 탭).
- 표(`table.table`) 셀 가운데/수직 정렬·패딩 8px·하단 margin 80px 유지.
- 페이지네이션 영역(`#pagelayout`) 가운데 정렬·위로 -60px 당김 유지.
- 슬라이스1·3+ 효과(pagination 색, banner)도 그대로(회귀 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
