### PR TITLE
css: 앵커 리셋(a:link/visited/hover/active) 외부 .css로 분리 (목록 10종)

### DIFF
--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -21,6 +21,7 @@
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -83,24 +84,6 @@ tr:hover { /* <tr>의 첫번째,두번째 형제 요소 제외하고 나머지 �
 
 .line2{
 	border-bottom: 3px solid darkgray;
-}
-
-a:link{
-color : black;
-text-decoration: none;
-}
-
-a:visited {
-  color : black;
-  text-decoration: none;
-}
-
-a:hover{
-color: #0897B4;
-}
-
-a:active{
-color: black;
 }
 
 #searcharea{

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -20,6 +20,7 @@
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -38,24 +39,6 @@
 .btn{
 	background-color:white;
 	border:white;
-}
-
-a:link{
-	color : black;
-	text-decoration: none;
-}
-
-a:visited {
-  color : black;
-  text-decoration: none;
-}
-
-a:hover{
-	color: #0897B4;
-}
-
-a:active{
-	color: black;
 }
 
 #searcharea{

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -19,6 +19,7 @@
 <title>HUEAT</title>
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -37,24 +38,6 @@
 .btn{
 	background-color:white;
 	border:white;
-}
-
-a:link{
-	color : black;
-	text-decoration: none;
-}
-
-a:visited {
-  color : black;
-  text-decoration: none;
-}
-
-a:hover{
-	color: #0897B4;
-}
-
-a:active{
-	color: black;
 }
 
 #searcharea{

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -20,6 +20,7 @@
 <title>HUEAT</title>
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 #titlearea{
 			text-align: center;
@@ -87,24 +88,6 @@ table td:last-child {
 
 .line2{
 	border-bottom: 3px solid darkgray;
-}
-
-a:link{
-color : black;
-text-decoration: none;
-}
-
-a:visited {
-  color : black;
-  text-decoration: none;
-}
-
-a:hover{
-color: #0897B4;
-}
-
-a:active{
-color: black;
 }
 
 #searcharea{

--- a/src/main/webapp/hugesoinfo/hugesomap.jsp
+++ b/src/main/webapp/hugesoinfo/hugesomap.jsp
@@ -15,6 +15,7 @@
 <title>휴게소 찾기</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 	<style type="text/css">
 		#area{
 			margin-top: 7%;
@@ -75,24 +76,6 @@
 		
 		}
 		
-		
-		a:link{
-			color : black;
-			text-decoration: none;
-		}
-		
-		a:visited {
-			color : black;
-			text-decoration: none;
-		}
-		
-		a:hover{
-			color: #0897B4;
-		}
-		
-		a:active{
-			color: black;
-		}
 		
 		ul{
 			cursor: pointer;

--- a/src/main/webapp/layout/anchor-reset.css
+++ b/src/main/webapp/layout/anchor-reset.css
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+/* 목록 페이지 공통 앵커 리셋 (admin·my·휴게소 목록 10종 공용).
+   여러 목록 JSP의 <style>에 공백 차이만 두고 복붙돼 있던 앵커 4규칙
+   (a:link / a:visited / a:hover / a:active)을 추출.
+   각 페이지 <head>에서 <link href="layout/anchor-reset.css">로 로드한다.
+   ※ 게시판 3종(eventList/noticeList/qaList)은 결합 셀렉터(a:link,a:visited)에
+      hover/active가 없는 다른 구조라 제외하고 인라인에 그대로 둔다. */
+a:link {
+	color: black;
+	text-decoration: none;
+}
+a:visited {
+	color: black;
+	text-decoration: none;
+}
+a:hover {
+	color: #0897B4;
+}
+a:active {
+	color: black;
+}

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -17,6 +17,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -67,24 +68,6 @@ ul.tabs li#first:hover, ul.tabs li#next:hover {
 
 ul.tabs li span {
 	font-weight: bold;
-}
-
-a:link {
-	color: black;
-	text-decoration: none;
-}
-
-a:visited {
-	color: black;
-	text-decoration: none;
-}
-
-a:hover {
-	color: #0897B4;
-}
-
-a:active {
-	color: black;
 }
 
 div.admineventlist {

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -17,6 +17,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -68,24 +69,6 @@ ul.tabs li#first:hover, ul.tabs li#event:hover {
 
 ul.tabs li span {
 	font-weight: bold;
-}
-
-a:link {
-	color: black;
-	text-decoration: none;
-}
-
-a:visited {
-	color: black;
-	text-decoration: none;
-}
-
-a:hover {
-	color: #0897B4;
-}
-
-a:active {
-	color: black;
 }
 
 div.adminnoticelist {

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -17,6 +17,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -64,24 +65,6 @@ ul.tabs li#next:hover, ul.tabs li#event:hover {
 
 ul.tabs li span {
 	font-weight: bold;
-}
-
-a:link {
-	color: black;
-	text-decoration: none;
-}
-
-a:visited {
-	color: black;
-	text-decoration: none;
-}
-
-a:hover {
-	color: #0897B4;
-}
-
-a:active {
-	color: black;
 }
 
 div.adminqnalist {

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 ul.tabs {
    margin: 0px;
@@ -65,24 +66,6 @@ ul.tabs li#next:hover {
 
 ul.tabs li span {
    font-weight: bold;
-}
-
-a:link {
-   color: black;
-   text-decoration: none;
-}
-
-a:visited {
-   color: black;
-   text-decoration: none;
-}
-
-a:hover {
-   color: #0897B4;
-}
-
-a:active {
-   color: black;
 }
 
 div.reviewlist {

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -22,6 +22,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <style type="text/css">
 ul.tabs {
 	margin: 0px;
@@ -68,24 +69,6 @@ ul.tabs li#first:hover {
 
 ul.tabs li span {
 	font-weight: bold;
-}
-
-a:link {
-	color: black;
-	text-decoration: none;
-}
-
-a:visited {
-	color: black;
-	text-decoration: none;
-}
-
-a:hover {
-	color: #0897B4;
-}
-
-a:active {
-	color: black;
 }
 
 div.reviewlist {


### PR DESCRIPTION
## 개요
2단계 리팩터링 CSS 슬라이스4. 여러 목록 JSP의 인라인 `<style>`에 **공백 차이만 두고 복붙**돼 있던 앵커 리셋 4규칙(`a:link`/`a:visited`/`a:hover`/`a:active`)을 신설 `layout/anchor-reset.css`로 추출(dedup). 검증된 메커니즘(외부 .css + 페이지별 `<link>` opt-in, Bootstrap link 뒤·`<style>` 앞 배치) 동일 적용.

## 적용 범위 — 깨끗한 동일 그룹 10종
- mypage 5: `admineventlist` · `adminnoticelist` · `adminqnalist` · `myqnalist` · `myreviewlist`
- hugesoinfo 5: `hugesolist` · `hugesolist2` · `hugesolist2search` · `hugesolistsearch` · `hugesomap`

10종 모두 4개 분리 규칙을 LVHA 순서로 보유, 속성·값 동일(차이는 공백뿐 — `color : black` vs `color: black`, 들여쓰기).

## 제외 — 게시판 3종 (eventList/noticeList/qaList)
구조 분기로 dedup 불가 → 인라인 잔류:
1. **단일 결합 셀렉터** `a:link, a:visited`(4규칙 아님)
2. 속성 순서 **반대**(text-decoration→color)
3. **`a:hover`/`a:active` 규칙 자체가 없음**

## 동작 보존 근거
- **캐스케이드**: 의사클래스 명시도 (0,1,0) > Bootstrap 5 Reboot `a` (0,0,1) → `info.jsp` Bootstrap 재로딩·외부화(앞 이동)에도 결과 불변. 각 host 인라인에 경쟁 `a` 규칙 0건 확인.
- **오병합 검증**: 10종 삭제 CSS = `anchor-reset.css` 본문 공백무시 **바이트 동일**.
- 보안 출력 인코딩 무관(순수 CSS 이동). 동작·시각 변화 0.

## 검증
- ✅ 오병합 검증 ALL MATCH (10종)
- ✅ `git diff --numstat` 파일당 +1/-18, 줄끝 churn 0
- ✅ JspC EXIT=0 (122 JSP, 0 오류)
- ✅ /code-review high — findings 0건
- ⚠ **IntelliJ+Tomcat 시각 스모크 필요**: 10종 목록 링크 색(검정)·hover 색(#0897B4) 유지, 신규 `anchor-reset.css` 200 로드, 게시판 3종 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
