### PR TITLE
css: 마이페이지 탭 구조 4규칙 외부 .css로 분리 (mypage 5종)

### DIFF
--- a/src/main/webapp/layout/mypage-tabs.css
+++ b/src/main/webapp/layout/mypage-tabs.css
@@ -1,0 +1,35 @@
+@charset "UTF-8";
+/* 마이페이지 탭 구조 공통 스타일 (admin·my 목록 5종 공용).
+   admineventlist/adminnoticelist/adminqnalist/myqnalist/myreviewlist의 <style>에
+   공백 차이만 두고 복붙돼 있던 탭 구조 4규칙(ul.tabs / ul.tabs li / .tab-content /
+   ul.tabs li span)을 추출. 각 페이지 <head>에서 <link href="layout/mypage-tabs.css">로 로드.
+   ※ 활성/강조 규칙(ul.tabs li#first/#next/#event 계열·#first/#next 자기탭 강조)은 페이지마다
+      달라(슬라이스3 ⏸ 사유) 각 host 인라인 <style>에 그대로 둔다. */
+ul.tabs {
+	margin: 0px;
+	padding: 0px;
+	list-style: none;
+	display: flex;
+	justify-content: center;
+}
+
+ul.tabs li {
+	background: none;
+	color: #222;
+	cursor: pointer;
+	width: 90px;
+	height: 45px;
+	display: flex; /* 수정: 부모 요소를 플렉스 박스로 설정 */
+	align-items: center; /* 수정: 수직 가운데 정렬 */
+	justify-content: center;
+}
+
+.tab-content {
+	display: none;
+	background: white;
+	padding: 15px;
+}
+
+ul.tabs li span {
+	font-weight: bold;
+}

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -18,25 +18,8 @@
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <style type="text/css">
-ul.tabs {
-	margin: 0px;
-	padding: 0px;
-	list-style: none;
-	display: flex;
-	justify-content: center;
-}
-
-ul.tabs li {
-   background: none;
-   color: #222;
-   cursor: pointer;
-   width: 90px;
-   height: 45px;
-   display: flex; /* 수정: 부모 요소를 플렉스 박스로 설정 */
-   align-items: center; /* 수정: 수직 가운데 정렬 */
-   justify-content: center; 
-}
 ul.tabs li#first{
 	  border-radius: 100px;
 	  border: 1px solid #ccc;
@@ -60,15 +43,6 @@ ul.tabs li#first:hover, ul.tabs li#next:hover {
     color: #fff;
 }
 
-.tab-content {
-	display: none;
-	background: white;
-	padding: 15px;
-}
-
-ul.tabs li span {
-	font-weight: bold;
-}
 
 div.admineventlist {
 	width: 100%;

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -18,25 +18,8 @@
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <style type="text/css">
-ul.tabs {
-	margin: 0px;
-	padding: 0px;
-	list-style: none;
-	display: flex;
-	justify-content: center;
-}
-
-ul.tabs li {
-   background: none;
-   color: #222;
-   cursor: pointer;
-   width: 90px;
-   height: 45px;
-   display: flex; /* 수정: 부모 요소를 플렉스 박스로 설정 */
-   align-items: center; /* 수정: 수직 가운데 정렬 */
-   justify-content: center; 
-}
 ul.tabs li#first{
 	  border-radius: 100px;
 	  border: 1px solid #ccc;
@@ -61,15 +44,6 @@ ul.tabs li#first:hover, ul.tabs li#event:hover {
     color: #fff;
 }
 
-.tab-content {
-	display: none;
-	background: white;
-	padding: 15px;
-}
-
-ul.tabs li span {
-	font-weight: bold;
-}
 
 div.adminnoticelist {
 	width: 100%;

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -18,25 +18,8 @@
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <style type="text/css">
-ul.tabs {
-	margin: 0px;
-	padding: 0px;
-	list-style: none;
-	display: flex;
-	justify-content: center;
-}
-
-ul.tabs li {
-   background: none;
-   color: #222;
-   cursor: pointer;
-   width: 90px;
-   height: 45px;
-   display: flex; /* 수정: 부모 요소를 플렉스 박스로 설정 */
-   align-items: center; /* 수정: 수직 가운데 정렬 */
-   justify-content: center; 
-}
 
 ul.tabs li#next, ul.tabs li#event {
 	   border: 1px solid #ccc;
@@ -57,15 +40,6 @@ ul.tabs li#next:hover, ul.tabs li#event:hover {
    color: #fff;
 }
 
-.tab-content {
-	display: none;
-	background: white;
-	padding: 15px;
-}
-
-ul.tabs li span {
-	font-weight: bold;
-}
 
 div.adminqnalist {
 	width: 100%;

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -20,25 +20,8 @@
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <style type="text/css">
-ul.tabs {
-   margin: 0px;
-   padding: 0px;
-   list-style: none;
-   display: flex;
-   justify-content: center;
-}
-
-ul.tabs li {
-   background: none;
-   color: #222;
-   cursor: pointer;
-   width: 90px;
-   height: 45px;
-   display: flex; /* 수정: 부모 요소를 플렉스 박스로 설정 */
-   align-items: center; /* 수정: 수직 가운데 정렬 */
-   justify-content: center; 
-}
 ul.tabs li#next {
    border: 1px solid #ccc;
    margin-left: 20px;
@@ -58,15 +41,6 @@ ul.tabs li#next:hover {
    color: #fff;
 }
 
-.tab-content {
-   display: none;
-   background: white;
-   padding: 15px;
-}
-
-ul.tabs li span {
-   font-weight: bold;
-}
 
 div.reviewlist {
    width: 100%;

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -23,25 +23,8 @@
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <style type="text/css">
-ul.tabs {
-	margin: 0px;
-	padding: 0px;
-	list-style: none;
-	display: flex;
-	justify-content: center;
-}
-
-ul.tabs li {
-   background: none;
-   color: #222;
-   cursor: pointer;
-   width: 90px;
-   height: 45px;
-   display: flex; /* 수정: 부모 요소를 플렉스 박스로 설정 */
-   align-items: center; /* 수정: 수직 가운데 정렬 */
-   justify-content: center; 
-}
 ul.tabs li#first {
    border: 1px solid #ccc;
    margin-right: 20px;
@@ -61,15 +44,6 @@ ul.tabs li#first:hover {
 	color: #fff;
 }
 
-.tab-content {
-	display: none;
-	background: white;
-	padding: 15px;
-}
-
-ul.tabs li span {
-	font-weight: bold;
-}
 
 div.reviewlist {
 	width: 100%;


### PR DESCRIPTION
## 개요 (CSS 슬라이스5)
mypage 5종(myqnalist/myreviewlist/adminqnalist/adminnoticelist/admineventlist)의 인라인 `<style>`에 공백 차이만 두고 복붙돼 있던 **탭 "구조 규칙" 4개**를 신설 `layout/mypage-tabs.css`로 추출했다. 슬라이스1~4(PR #92~#96)와 동일한 외부 .css + 페이지별 `<link>` opt-in 메커니즘.

## 범위
- **추출(구조 4규칙, 5종 동일):** `ul.tabs` / `ul.tabs li`(인라인 한글 주석 포함) / `.tab-content` / `ul.tabs li span`
- **인라인 잔류(절대 외부화 안 함):** 활성/강조 규칙(`ul.tabs li#first/#next/#event` 계열·자기탭 초록 강조·`:hover`). 페이지마다 강조 대상·조합·마진이 달라(슬라이스3 ⏸ 사유) host 인라인 유지.

## 구현
- 구조 규칙이 `<style>` 상단 2규칙 + 하단 2규칙으로 뭉쳐 있고 활성 규칙이 그 사이에 끼어 있어, 파일당 **연속 2구간**만 삭제(셀렉터 4분할 불필요). 삭제줄에 활성 규칙 0건 확인.
- `<link>`는 `anchor-reset.css` 링크 뒤(Bootstrap 뒤·`<style>` 앞)에 추가 → 캐스케이드 보존.

## 캐스케이드 안전성
- 활성 규칙은 id 명시도 우위(`#first`=1,0,0 등)라 같은 속성 충돌 시 **소스 순서 무관 승리**.
- 구조 4규칙은 `<style>` 최상단이라 외부화 후에도 활성 규칙보다 **앞** 로드 → 인트라페이지 순서 불변.
- Bootstrap에 `ul.tabs`/`ul.tabs li span` 동명 규칙 없음, `.tab-content`는 자식 셀렉터(`.tab-content > .tab-pane`)만 → 본 요소 충돌 없음.

## 검증
- ✅ 오병합 byte: 5종 삭제분 == `mypage-tabs.css` 본문 ×5 (인라인 주석 포함 공백무시 바이트 동일)
- ✅ JspC: `EXIT=0` (122 JSP 변환+컴파일, 0 errors)
- ✅ `/code-review high`: 발견 0건
- ✅ numstat 파일당 `+1/-27`, 줄끝 churn 0
- ⚠ **IntelliJ+Tomcat 시각 스모크 필요**(CSS 자동 게이트 없음): 5종 탭 모양·정렬·폰트(bold) 동일, 활성탭 초록(#5b954d) 강조 유지, hover 강조 유지, `mypage-tabs.css` 200 로드, 표/페이지네이션/배너 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)