### PR TITLE
css: 마이페이지 잔여 공통 규칙 5개 외부 .css로 분리 (mypage 5종)

### DIFF
--- a/src/main/webapp/layout/mypage-misc.css
+++ b/src/main/webapp/layout/mypage-misc.css
@@ -1,0 +1,33 @@
+@charset "UTF-8";
+/* 마이페이지 목록 공통 스타일 (admin·my 목록 5종 공용) — 잔여 공통 규칙.
+   admineventlist/adminnoticelist/adminqnalist/myqnalist/myreviewlist의 <style>에
+   바이트(공백무시) 동일하게 복붙돼 있던 5규칙(div.container / input[type="checkbox"] /
+   td / .table-bordered td.day / div.span-container span)을 추출.
+   각 페이지 <head>에서 <link href="layout/mypage-misc.css">로 로드한다.
+   ※ #btndel은 adminqnalist만 border-radius·box-shadow가 달라(분기) 각 host 인라인에 남겨둔다. */
+div.container {
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 50px;
+	margin-top: 128px;
+}
+
+input[type="checkbox"] {
+	width: 10px;
+	height: 10px;
+	cursor: pointer;
+}
+td{
+font-size: 14px;
+}
+.table-bordered	td.day {
+	font-size: 12px;
+	color: #b4a8a8;
+	}
+
+div.span-container span{
+	z-index: 9999;
+	color: white;
+	position: relative;
+
+}

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
 <style type="text/css">
 ul.tabs li#first{
 	  border-radius: 100px;
@@ -51,33 +52,6 @@ div.admineventlist {
 	margin-right: auto;
 }
 
-div.container {
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 50px;
-	margin-top: 128px;
-}
-
-input[type="checkbox"] {
-	width: 10px;
-	height: 10px;
-	cursor: pointer;
-}
-td{
-font-size: 14px;
-}
-.table-bordered	td.day {
-	font-size: 12px;
-	color: #b4a8a8;
-	}
-
-
-	div.span-container span{
-		z-index: 9999;
-		color: white;
-		position: relative;
-
-}
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
 <style type="text/css">
 ul.tabs li#first{
 	  border-radius: 100px;
@@ -52,33 +53,6 @@ div.adminnoticelist {
 	margin-right: auto;
 }
 
-div.container {
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 50px;
-	margin-top: 128px;
-}
-
-input[type="checkbox"] {
-	width: 10px;
-	height: 10px;
-	cursor: pointer;
-}
-td{
-font-size: 14px;
-}
-.table-bordered	td.day {
-	font-size: 12px;
-	color: #b4a8a8;
-	}
-
-
-	div.span-container span{
-		z-index: 9999;
-		color: white;
-		position: relative;
-
-}
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;

--- a/src/main/webapp/mypage/adminqnalist.jsp
+++ b/src/main/webapp/mypage/adminqnalist.jsp
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
 <style type="text/css">
 
 ul.tabs li#next, ul.tabs li#event {
@@ -48,33 +49,6 @@ div.adminqnalist {
 	margin-right: auto;
 }
 
-div.container {
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 50px;
-	margin-top: 128px;
-}
-
-input[type="checkbox"] {
-	width: 10px;
-	height: 10px;
-	cursor: pointer;
-}
-td{
-font-size: 14px;
-}
-.table-bordered	td.day {
-	font-size: 12px;
-	color: #b4a8a8;
-	}
-
-
-	div.span-container span{
-		z-index: 9999;
-		color: white;
-		position: relative;
-
-}
 	#btndel{
 	    background-color:#fb4357;
 	    color: #fff;

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -21,6 +21,7 @@
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
 <style type="text/css">
 ul.tabs li#next {
    border: 1px solid #ccc;
@@ -50,32 +51,6 @@ div.reviewlist {
    padding-bottom: 40px;
 }
 
-div.container {
-   margin-left: auto;
-   margin-right: auto;
-   margin-bottom: 50px;
-   margin-top: 128px;
-}
-
-input[type="checkbox"] {
-   width: 10px;
-   height: 10px;
-   cursor: pointer;
-}
-td{
-font-size: 14px;
-}
-.table-bordered	td.day {
-	font-size: 12px;
-	color: #b4a8a8;
-	}
-
-   div.span-container span{
-      z-index: 9999;
-      color: white;
-      position: relative;
-
-}
 
 	#btndel{
 	    background-color:#fb4357;

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -24,6 +24,7 @@
 <link rel="stylesheet" type="text/css" href="layout/mypage-list.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
 <style type="text/css">
 ul.tabs li#first {
    border: 1px solid #ccc;
@@ -53,32 +54,6 @@ div.reviewlist {
 	padding-bottom: 40px;
 }
 
-div.container {
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 50px;
-	margin-top: 128px;
-}
-
-input[type="checkbox"] {
-	width: 10px;
-	height: 10px;
-	cursor: pointer;
-}
-td{
-font-size: 14px;
-}
-.table-bordered	td.day {
-	font-size: 12px;
-	color: #b4a8a8;
-	}
-
-	div.span-container span{
-		z-index: 9999;
-		color: white;
-		position: relative;
-
-}
 
 	#btndel{
 	    background-color:#fb4357;


### PR DESCRIPTION
## 배경
2단계 리팩터링 CSS 슬라이스 작업(슬라이스6). 여러 목록 JSP의 인라인 `<style>`에 바이트(공백무시) 동일하게 복붙된 CSS를 공용 외부 .css로 추출(dedup)하는 작업의 연속이다. 슬라이스1·3+·3++·4·5에서 mypage 5종의 pagination·banner앞3·#pagelayout·table.table·앵커4·탭구조4를 이미 외부화했고, 이번엔 host 인라인에 **남아 있던 5종 동일 공통 규칙**을 추출한다.

## 변경
mypage 목록 5종(`myqnalist`·`myreviewlist`·`adminqnalist`·`adminnoticelist`·`admineventlist`)의 인라인 `<style>`에 동일 복붙돼 있던 공통 규칙 5개를 신설 `layout/mypage-misc.css`로 추출하고, 각 host에 `<link>` 1줄 추가.

**추출 5규칙(5종 전수 동일 확인):**
- `div.container` (margin auto·bottom 50px·top 128px)
- `input[type="checkbox"]` (width/height 10px·cursor pointer)
- `td` (font-size 14px)
- `.table-bordered td.day` (font-size 12px·color #b4a8a8)
- `div.span-container span` (z-index 9999·color white·position relative)

**제외 — `#btndel`:** adminqnalist만 `border-radius:5px`·box-shadow 없음으로 분기(나머지 4종은 10px+box-shadow) → 슬라이스3 교훈("한 곳이라도 다르면 dedup 불가")에 따라 공통화에서 제외, 5종 모두 인라인 잔류.

`<link>`는 기존 opt-in 클러스터 끝(`mypage-tabs.css` 뒤·인라인 `<style>` 앞)에 배치(캐스케이드 보존, context-상대경로).

## 동작 보존 / 검증
- **순수 리팩터(시각·동작 변화 0)**
- **오병합 byte 검증:** 5종 삭제분 == `mypage-misc.css` 본문 ×5 바이트(공백무시) 동일(1430=286×5)
- **명시도/캐스케이드 불변:** `mypage-list.css`는 font-size 미설정 → `td` 충돌 없음 / `.table-bordered td.day`(0,2,1) > `td`(0,0,1) / `banner.css`의 `div.span-container`(부모)와 자식 `span`은 다른 요소라 로드순서 무관
- **JspC EXIT=0**(122 JSP 변환+컴파일)
- **/code-review high 0건**
- `git diff --numstat`: 파일당 +1(link)/−26~27(블록), 줄끝 churn 0

## ⚠ 스모크 체크(IntelliJ+Tomcat, CSS는 자동 게이트 없음)
mypage 5종에서: 컨테이너 상/하단 margin(top 128px·bottom 50px)·체크박스 크기·표 폰트(td 14px / day 12px·회색)·배너 span(흰색·전면)·`#btndel`(삭제버튼) 모양 회귀 없음 + `mypage-misc.css` 200 로드 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)