### PR TITLE
css: 마이페이지 삭제버튼 #btndel 4종 외부 .css로 분리 (슬라이스7)

### DIFF
--- a/src/main/webapp/layout/mypage-btndel.css
+++ b/src/main/webapp/layout/mypage-btndel.css
@@ -1,0 +1,16 @@
+@charset "UTF-8";
+/* 마이페이지 삭제버튼 스타일 (#btndel) — admin·my 목록 4종 공용.
+   admineventlist/adminnoticelist/myqnalist/myreviewlist의 <style>에 바이트(공백무시)
+   동일하게 복붙돼 있던 #btndel 규칙을 추출.
+   각 페이지 <head>에서 <link href="layout/mypage-btndel.css">로 로드한다.
+   ※ adminqnalist는 border-radius:5px·box-shadow 없음(분기)이라 제외 — 인라인 그대로 둔다. */
+#btndel{
+	background-color:#fb4357;
+	color: #fff;
+	border:none;
+	border-radius:10px;
+	box-shadow: 0px 0px 2px 2px #fb4357;
+	width: 45px;
+	height: 30px;
+	font-size: 13px;
+}

--- a/src/main/webapp/mypage/admineventlist.jsp
+++ b/src/main/webapp/mypage/admineventlist.jsp
@@ -20,6 +20,7 @@
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-btndel.css">
 <style type="text/css">
 ul.tabs li#first{
 	  border-radius: 100px;
@@ -52,16 +53,6 @@ div.admineventlist {
 	margin-right: auto;
 }
 
-	#btndel{
-	    background-color:#fb4357;
-	    color: #fff;
-	    border:none;
-	    border-radius:10px;
-	    box-shadow: 0px 0px 2px 2px #fb4357;
-	    width: 45px;
-		height: 30px;
-		font-size: 13px;
-	}
 
 </style>
 <script type="text/javascript">

--- a/src/main/webapp/mypage/adminnoticelist.jsp
+++ b/src/main/webapp/mypage/adminnoticelist.jsp
@@ -20,6 +20,7 @@
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-btndel.css">
 <style type="text/css">
 ul.tabs li#first{
 	  border-radius: 100px;
@@ -53,16 +54,6 @@ div.adminnoticelist {
 	margin-right: auto;
 }
 
-	#btndel{
-	    background-color:#fb4357;
-	    color: #fff;
-	    border:none;
-	    border-radius:10px;
-	    box-shadow: 0px 0px 2px 2px #fb4357;
-	    width: 45px;
-		height: 30px;
-		font-size: 13px;
-	}
 </style>
 <script type="text/javascript">
 	$(function(){

--- a/src/main/webapp/mypage/myqnalist.jsp
+++ b/src/main/webapp/mypage/myqnalist.jsp
@@ -22,6 +22,7 @@
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-btndel.css">
 <style type="text/css">
 ul.tabs li#next {
    border: 1px solid #ccc;
@@ -52,16 +53,6 @@ div.reviewlist {
 }
 
 
-	#btndel{
-	    background-color:#fb4357;
-	    color: #fff;
-	    border:none;
-	    border-radius:10px;
-	    box-shadow: 0px 0px 2px 2px #fb4357;
-	    width: 45px;
-		height: 30px;
-		font-size: 13px;
-	}
 
 </style>
 <script type="text/javascript">

--- a/src/main/webapp/mypage/myreviewlist.jsp
+++ b/src/main/webapp/mypage/myreviewlist.jsp
@@ -25,6 +25,7 @@
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-tabs.css">
 <link rel="stylesheet" type="text/css" href="layout/mypage-misc.css">
+<link rel="stylesheet" type="text/css" href="layout/mypage-btndel.css">
 <style type="text/css">
 ul.tabs li#first {
    border: 1px solid #ccc;
@@ -55,16 +56,6 @@ div.reviewlist {
 }
 
 
-	#btndel{
-	    background-color:#fb4357;
-	    color: #fff;
-	    border:none;
-	    border-radius:10px;
-	    box-shadow: 0px 0px 2px 2px #fb4357;
-	    width: 45px;
-		height: 30px;
-		font-size: 13px;
-	}
 		
 
 


### PR DESCRIPTION
## 개요
CSS 슬라이스7. mypage 목록 4종의 인라인 `<style>`에 공백무시 바이트 동일하게 복붙돼 있던
`#btndel`(삭제버튼) 규칙을 `layout/mypage-btndel.css`로 추출하고, 각 페이지에 `<link>`로
opt-in 로드한다. **동작·시각 변화 0의 순수 리팩터.**

## 변경
- 신설: `layout/mypage-btndel.css` (`#btndel` 1규칙 + 헤더 주석)
- `<link>` 추가 + 인라인 규칙 제거 (4종): `myreviewlist` / `myqnalist` / `admineventlist` / `adminnoticelist`
- 파일당 +1(link) / -10(블록), 줄끝 churn 0

## 분기·범위
- **adminqnalist 제외**: `border-radius:5px`·box-shadow 없음(분기)이라 인라인 그대로 잔류.
- **shop/shopList 범위 밖**: `#btndel`은 JS 핸들러뿐 CSS 규칙 없음.
- 각 파일의 `$("#btndel").click(...)` JS 핸들러는 동작 코드라 미접촉.

## 캐스케이드 안전성
`#btndel`은 id 셀렉터(명시도 1,0,0)이고 경쟁 규칙이 0건이라, 외부화(소스순서 앞으로 이동)해도
명시도 우위로 결과 불변.

## 검증
- ✅ 오병합 byte 검증: 4종 삭제분 == `mypage-btndel.css` 본문 ×4 (공백무시 동일)
- ✅ JspC: 122 JSP 변환+컴파일, 0 errors
- ✅ `git diff -U0`: 삭제 `-`줄에 `#btndel` 외 규칙 안 섞임. adminqnalist/shopList 미변경
- ✅ /code-review high: findings 0
- ⏳ IntelliJ+Tomcat 시각 스모크(사용자): 4종 삭제버튼 동일(빨강·모서리 10px·그림자·45×30·폰트 13px) + adminqnalist 기존 그대로(모서리 5px·그림자 없음) + `mypage-btndel.css` 200 로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)