### PR TITLE
css: 등록버튼 button.col 12종 외부 .css로 분리 (슬라이스8)

### DIFF
--- a/src/main/webapp/eventboard/eventDetail.jsp
+++ b/src/main/webapp/eventboard/eventDetail.jsp
@@ -13,12 +13,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>이벤트 상세</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   span.day {
     float: right;

--- a/src/main/webapp/eventboard/eventForm.jsp
+++ b/src/main/webapp/eventboard/eventForm.jsp
@@ -9,12 +9,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>이벤트 작성</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
    table.table tr, table.table td{
   	border: 0px;

--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -18,12 +18,9 @@
 
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
  <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   #pagelayout {
     margin-left: 20%; 

--- a/src/main/webapp/eventboard/eventUpdateForm.jsp
+++ b/src/main/webapp/eventboard/eventUpdateForm.jsp
@@ -11,12 +11,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>이벤트 수정</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   #showing {
     width: 500px;

--- a/src/main/webapp/layout/button-col.css
+++ b/src/main/webapp/layout/button-col.css
@@ -1,0 +1,11 @@
+@charset "UTF-8";
+/* 게시판/쇼핑 등록·작성 버튼 스타일 (button.col) — 목록·상세·작성·수정 폼 12종 공용.
+   notice/event/qa 게시판 11종(List/Detail/Form/UpdateForm 계열) + shop/shopForm의 인라인
+   <style>에 바이트(공백무시) 동일하게 복붙돼 있던 button.col 규칙을 추출.
+   각 페이지 <head>에서 <link href="layout/button-col.css">로 로드한다.
+   ※ 분기라 제외: layout/main.jsp(margin-bottom:6%·전역 푸터)·shop/shopList(width/height/color)·
+      reviewboard/reviewForm·reviewUpdateForm(margin-left:-118%). 해당 파일은 인라인 그대로 둔다. */
+button.col {
+	background-color: #618E6E;
+	right: 20%;
+}

--- a/src/main/webapp/noticeboard/noticeDetail.jsp
+++ b/src/main/webapp/noticeboard/noticeDetail.jsp
@@ -13,12 +13,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>공지 상세</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   span.day {
     float: right;

--- a/src/main/webapp/noticeboard/noticeForm.jsp
+++ b/src/main/webapp/noticeboard/noticeForm.jsp
@@ -9,12 +9,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>공지 작성</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   table.table tr, table.table td{
   	border: 0px;

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -17,12 +17,9 @@
 
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   #pagelayout {
     margin-left: 20%; 

--- a/src/main/webapp/noticeboard/noticeUpdateForm.jsp
+++ b/src/main/webapp/noticeboard/noticeUpdateForm.jsp
@@ -11,12 +11,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>공지 수정</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   #showing {
     width: 500px;

--- a/src/main/webapp/qaboard/qaDetail.jsp
+++ b/src/main/webapp/qaboard/qaDetail.jsp
@@ -29,12 +29,9 @@ dao.updateReadcount(q_num);
 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 %>
 
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   
   span.day {
     float: right;

--- a/src/main/webapp/qaboard/qaForm.jsp
+++ b/src/main/webapp/qaboard/qaForm.jsp
@@ -9,12 +9,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>문의 작성</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
   table.table tr,table.table td{
   	border: none;
   }

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -17,12 +17,9 @@
 <title>QnA 게시판</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
    
   
   a:link, a:visited {

--- a/src/main/webapp/shop/shopForm.jsp
+++ b/src/main/webapp/shop/shopForm.jsp
@@ -12,12 +12,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <title>상품 등록</title>
+<link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <style type="text/css">
 
-  button.col {
-    background-color: #618E6E;
-    right: 20%;
-  }
    table.table tr, table.table td{
   	border: 0px;
   }


### PR DESCRIPTION
## 개요
CSS 슬라이스8. 게시판·쇼핑 페이지의 인라인 `<style>`에 공백무시 바이트 동일하게 복붙돼 있던
`button.col`(등록/작성 버튼) 규칙을 `layout/button-col.css`로 추출하고, 각 페이지에 `<link>`로
opt-in 로드한다. **동작·시각 변화 0의 순수 리팩터.**

## 변경 (13파일)
- 신설: `layout/button-col.css` (`button.col {background-color:#618E6E; right:20%}` 1규칙 + 헤더 주석)
- 인라인 규칙 제거 + `<link>` 추가 (동일집합 12종, 파일당 +1/-4):
  - notice 4종 (List/Detail/Form/UpdateForm)
  - event 4종 (List/Detail/Form/UpdateForm)
  - qa 3종 (List/Detail/Form)
  - shop 1종 (shopForm)

## 분기·범위 (제외 — 인라인 그대로 잔류)
- `layout/main.jsp`: `margin-bottom:6%`(right 없음) — **전역 푸터**
- `shop/shopList`: `width/height/color` 등 별도
- `reviewboard/reviewForm`·`reviewUpdateForm`: `margin-left:-118%` 등
- qaList의 `$("button.col")` JS 핸들러: 동작 코드라 미접촉

## 캐스케이드 안전성
- `main.jsp` 푸터의 `button.col`(분기)과 외부화된 link은 상대 소스순서가 보존됨(둘 다 footer보다 앞).
  겹치는 속성은 `background-color`(동일값)뿐이라 시각 결과 불변.
- `button.col` 명시도(0,0,1,1) > Bootstrap `.col`(0,0,1,0)이고 Bootstrap 뒤 로드 → 결과 동일.

## 검증
- ✅ 오병합 byte 검증: 12종 삭제분 == `button-col.css` 본문 ×12 (공백무시 동일)
- ✅ JspC: 122 JSP 변환+컴파일, 0 errors
- ✅ `git diff -U0`: 삭제 `-`줄은 `button.col` 4줄 블록 ×12뿐. 분기 4종/JS 미변경
- ✅ /code-review: findings 0
- ⏳ IntelliJ+Tomcat 시각 스모크(사용자): 12종 등록버튼 모양 동일(초록 #618E6E·right 20%) + 분기 4종(main.jsp 마진·shopList 크기·review 마진) 회귀 없음 + `button-col.css` 200 로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)