### PR TITLE
css: 게시판 목록 결합형 앵커 리셋 3종 외부 .css로 분리 (슬라이스9)

### DIFF
--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
  <style type="text/css">
 
   
@@ -28,11 +29,6 @@
     margin-top: -4%;" 
   }
   
-  a:link, a:visited {
-    text-decoration: none;
-    color: black;
-  
-  }
 	div.span-container span{
 		z-index: 9999;
 		color: white;

--- a/src/main/webapp/layout/anchor-reset-board.css
+++ b/src/main/webapp/layout/anchor-reset-board.css
@@ -1,0 +1,11 @@
+@charset "UTF-8";
+/* 게시판 목록 앵커 리셋 (eventList/noticeList/qaList 3종 공용) — 결합 셀렉터 변형.
+   세 목록 JSP의 <style>에 바이트(공백무시) 동일하게 복붙돼 있던 결합형 앵커 규칙
+   (a:link, a:visited { text-decoration:none; color:black })을 추출.
+   각 페이지 <head>에서 <link href="layout/anchor-reset-board.css">로 로드한다.
+   ※ layout/anchor-reset.css(slice4)와는 다른 집합이다 — 그쪽은 a:link/a:visited/a:hover/
+      a:active 4규칙 분리형(목록 10종)이고, 이 3종은 결합 셀렉터에 hover/active가 없어 별도 파일. */
+a:link, a:visited {
+	text-decoration: none;
+	color: black;
+}

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -18,6 +18,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <style type="text/css">
 
   
@@ -27,11 +28,6 @@
     margin-top: -4%;" 
   }
   
-  a:link, a:visited {
-    text-decoration: none;
-    color: black;
-  
-  }
   
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -18,15 +18,11 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <style type="text/css">
 
    
   
-  a:link, a:visited {
-    text-decoration: none;
-    color: black;
-  
-  }
    
 	div.span-container span{
 		z-index: 999;


### PR DESCRIPTION
## 개요
CSS 슬라이스9. 게시판 목록 3종(eventList/noticeList/qaList)의 인라인 `<style>`에 공백무시
바이트 동일하게 복붙돼 있던 **결합형 앵커 규칙**(`a:link, a:visited { text-decoration:none; color:black }`)을
신설 `layout/anchor-reset-board.css`로 추출. **동작·시각 변화 0의 순수 리팩터.**

> ⚠ **스택 PR**: 슬라이스8(#100, `refactor/css-board-buttoncol`) 위에 쌓임 — 같은 3개 파일을
> 건드리므로 base를 슬라이스8 브랜치로 두어 slice9 diff만 보이게 함. **#100 머지 후 자동으로 base가 main으로 재타겟됨.**

## 변경 (4파일)
- 신설: `layout/anchor-reset-board.css` (결합형 1규칙 + 헤더 주석)
- 인라인 규칙 제거 + `<link>` 추가 (3종, 파일당 +1/-5): noticeList / eventList / qaList

## slice4 anchor-reset.css와의 관계 (재사용 불가)
- slice4 `anchor-reset.css`: `a:link`/`a:visited`/`a:hover`/`a:active` **4규칙 분리형**(목록 10종).
- 본 3종: **결합 셀렉터** + hover/active 없음 → slice4에서 의도적 제외됐던 후속분이라 **별도 파일**.

## 캐스케이드 안전성
- 경쟁 앵커 규칙 **0건**(main.jsp·banner.css·pagination-b.css·인라인 어디에도 다른 `a:` 규칙 없음).
- Bootstrap `a`(0,0,0,1) < `a:link`/`a:visited`(0,0,1,1)이고 Bootstrap 뒤 로드 → 외부화(앞 이동)해도 결과 동일.
- link은 `button-col.css` 뒤(opt-in 클러스터 끝·`<style>` 앞).

## 검증
- ✅ 오병합 byte 검증: 3종 삭제분 == `anchor-reset-board.css` 본문 ×3 (공백무시 동일)
- ✅ JspC: 122 JSP 변환+컴파일, 0 errors
- ✅ `git diff -U0`: 삭제 `-`줄은 `a:link` 블록(5줄)뿐
- ✅ /code-review: findings 0
- ⏳ IntelliJ+Tomcat 시각 스모크(사용자): 3종 목록의 링크 색(검정)·밑줄 없음 동일 + `anchor-reset-board.css` 200 로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)