### PR TITLE
css: 게시판 목록 결합형 앵커 리셋 3종 외부 .css로 분리 (슬라이스9 복구)

### DIFF
--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
  <style type="text/css">
 
   
@@ -28,11 +29,6 @@
     margin-top: -4%;" 
   }
   
-  a:link, a:visited {
-    text-decoration: none;
-    color: black;
-  
-  }
 	div.span-container span{
 		z-index: 9999;
 		color: white;

--- a/src/main/webapp/layout/anchor-reset-board.css
+++ b/src/main/webapp/layout/anchor-reset-board.css
@@ -1,0 +1,11 @@
+@charset "UTF-8";
+/* 게시판 목록 앵커 리셋 (eventList/noticeList/qaList 3종 공용) — 결합 셀렉터 변형.
+   세 목록 JSP의 <style>에 바이트(공백무시) 동일하게 복붙돼 있던 결합형 앵커 규칙
+   (a:link, a:visited { text-decoration:none; color:black })을 추출.
+   각 페이지 <head>에서 <link href="layout/anchor-reset-board.css">로 로드한다.
+   ※ layout/anchor-reset.css(slice4)와는 다른 집합이다 — 그쪽은 a:link/a:visited/a:hover/
+      a:active 4규칙 분리형(목록 10종)이고, 이 3종은 결합 셀렉터에 hover/active가 없어 별도 파일. */
+a:link, a:visited {
+	text-decoration: none;
+	color: black;
+}

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -18,6 +18,7 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <style type="text/css">
 
   
@@ -27,11 +28,6 @@
     margin-top: -4%;" 
   }
   
-  a:link, a:visited {
-    text-decoration: none;
-    color: black;
-  
-  }
   
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/qaboard/qaList.jsp
+++ b/src/main/webapp/qaboard/qaList.jsp
@@ -18,15 +18,11 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
+<link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <style type="text/css">
 
    
   
-  a:link, a:visited {
-    text-decoration: none;
-    color: black;
-  
-  }
    
 	div.span-container span{
 		z-index: 999;


### PR DESCRIPTION
## 개요
슬라이스9를 **현재 main 위에 cherry-pick**해 깨끗이 올린 PR이다(원본 #101은 스택 base 설정 문제로
main에 전파되지 못함, 재타겟 시도 #102는 슬라이스7 revert가 섞여 폐기). 이 PR은 슬라이스9 커밋
하나만 담으며 main 대비 **슬라이스9의 4파일만** 변경한다(슬라이스7/8은 이미 main에 있고 보존됨).

게시판 목록 3종(eventList/noticeList/qaList)의 인라인 `<style>`에 공백무시 바이트 동일하게 복붙된
결합형 앵커 규칙(`a:link, a:visited {text-decoration:none; color:black}`)을 신설
`layout/anchor-reset-board.css`로 추출. **동작·시각 변화 0의 순수 리팩터.**

## slice4 anchor-reset.css와의 관계
slice4 `anchor-reset.css`(a:link/a:visited/a:hover/a:active 4규칙 분리형·10종)와 다른 집합 —
이 3종은 결합 셀렉터+hover/active 없어 slice4에서 의도적 제외됐던 후속분이라 별도 파일.

## 검증
- ✅ byte 검증: 3종 삭제분 == css본문 ×3 / ✅ JspC 0 errors(원본 #101에서) / ✅ /code-review 0건
- ✅ 캐스케이드: 경쟁 앵커 규칙 0건 + Bootstrap `a`(0,0,0,1) < `a:link`(0,0,1,1)·Bootstrap 뒤 로드라 불변
- ✅ main 대비 커밋 diff = 4파일(slice9)만, 슬라이스7/8 보존
- ⏳ IntelliJ 시각 스모크(3종 링크 검정·밑줄 없음·신규 css 200) 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)