### PR TITLE
css: 게시판 목록 div.span-container span(font-size:3em형) 외부 .css로 분리

### DIFF
--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -20,6 +20,7 @@
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
+<link rel="stylesheet" type="text/css" href="layout/span-container-board.css">
  <style type="text/css">
 
   
@@ -29,12 +30,6 @@
     margin-top: -4%;" 
   }
   
-	div.span-container span{
-		z-index: 9999;
-		color: white;
-		position: relative;
-		font-size: 3em;
-}
 
 		div.alldiv{
 		margin: 0 auto;

--- a/src/main/webapp/layout/span-container-board.css
+++ b/src/main/webapp/layout/span-container-board.css
@@ -1,0 +1,14 @@
+@charset "UTF-8";
+/* 게시판 목록 배너 텍스트(span) 공통 스타일.
+   noticeList/eventList/reviewList의 <style>에 바이트 동일하게 복붙돼 있던
+   div.span-container span(4속성·font-size:3em형)을 추출.
+   각 페이지 <head>에서 <link href="layout/span-container-board.css">로 로드한다.
+   ※ banner.css는 부모 div.span-container만 정의(자식 span은 여기서 담당).
+   ※ mypage-misc.css의 div.span-container span은 font-size 없는 3속성형이라 다른 집합.
+   ※ qaList는 z-index:999 분기라 제외(인라인 잔류). */
+div.span-container span{
+	z-index: 9999;
+	color: white;
+	position: relative;
+	font-size: 3em;
+}

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -19,6 +19,7 @@
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
+<link rel="stylesheet" type="text/css" href="layout/span-container-board.css">
 <style type="text/css">
 
   
@@ -29,12 +30,6 @@
   }
   
   
-	div.span-container span{
-		z-index: 9999;
-		color: white;
-		position: relative;
-		font-size: 3em;
-}
 
 	div.alldiv{
 		margin: 0 auto;

--- a/src/main/webapp/reviewboard/reviewList.jsp
+++ b/src/main/webapp/reviewboard/reviewList.jsp
@@ -16,6 +16,7 @@
 <title>후기게시판</title>
 <link rel="stylesheet" type="text/css" href="layout/pagination-b.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
+<link rel="stylesheet" type="text/css" href="layout/span-container-board.css">
 <style type="text/css">
 
   span.day{
@@ -41,12 +42,6 @@
   }
   
     
-	div.span-container span{
-		z-index: 9999;
-		color: white;
-		position: relative;
-		font-size: 3em;
-}
 
 </style>
 


### PR DESCRIPTION
## 개요
게시판 목록의 인라인 `<style>`에 바이트(공백무시) 동일하게 복붙돼 있던 배너 텍스트 규칙
`div.span-container span`(4속성·`z-index:9999`·`font-size:3em`)을 신설 `layout/span-container-board.css`로
추출(dedup)하고 각 페이지에 opt-in `<link>`를 추가했다. CSS 슬라이스 작업의 슬라이스10.

## 변경 (4파일)
- **신설** `layout/span-container-board.css` — 규칙 1개 + 헤더 주석(banner.css·mypage-misc.css와의 차이 교차 명시)
- `noticeList.jsp` / `eventList.jsp` / `reviewList.jsp` — 인라인 블록 삭제 + `<link>` 1줄 추가

## 범위 결정
- **3종 동일**(noticeList/eventList/reviewList): `z-index:9999`로 바이트 동일 → 외부화.
- **qaList 제외**: `z-index:999` 분기라 dedup 불가 → 인라인 잔류(미변경).
- **신규 파일 정당성**: `banner.css`는 부모 `div.span-container`만 정의(자식 span 미정의·경쟁 규칙 없음),
  `mypage-misc.css`의 동일 셀렉터는 `font-size` 없는 3속성형 → 다른 집합.
- link은 Bootstrap link 뒤·인라인 `<style>` 앞 opt-in 클러스터 끝에 배치(캐스케이드 보존).

## 검증
- JspC 통과(122 JSP, 0 errors).
- 오병합 byte 검증: `git diff -U0` 삭제분 == `span-container-board.css` 본문 ×3 바이트 동일.
- `git diff --numstat`: 3종 각 +1(link)/-6(블록), 줄끝 churn 0. qaList 미변경.
- /code-review high: 결함 0.
- ⏸ IntelliJ+Tomcat 시각 스모크(흰색·font-size 3em·z-index, qaList 회귀 없음, css 200 로드)는 수동 확인 대기.

## 제약
동작·시각 변화 0의 순수 리팩터. 보안 출력 인코딩 약화 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
