### PR TITLE
css: 게시판 목록 잔여 레이아웃 규칙(#pagelayout·alldiv·tablediv) 외부 .css로 분리 (슬라이스11)

### DIFF
--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -21,38 +21,10 @@
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <link rel="stylesheet" type="text/css" href="layout/span-container-board.css">
+<link rel="stylesheet" type="text/css" href="layout/board-layout.css">
  <style type="text/css">
 
   
-  #pagelayout {
-    margin-left: 20%; 
-    margin-bottom: 3%;
-    margin-top: -4%;" 
-  }
-  
-
-		div.alldiv{
-		margin: 0 auto;
-		width: 80%;
-		border: 0px solid black;
-
-	}
-	
-	div.tablediv{
-		margin:0 auto;
-		padding-top: 5%;
-		border: 0px solid red;
-		width: 70%;
-		display: block;
-	}
-	
-	#pagelayout{
-		margin:0 auto;
-		border: 0px solid yellow;
-		padding-top: 4%;
-		width: 70%;
-		display: block;
-	}
 
 
 

--- a/src/main/webapp/layout/board-layout.css
+++ b/src/main/webapp/layout/board-layout.css
@@ -1,0 +1,35 @@
+@charset "UTF-8";
+/* 게시판 목록 레이아웃 위치 규칙(공통).
+   noticeList/eventList의 <style>에 바이트 동일하게 복붙돼 있던
+   #pagelayout(2회 정의)·div.alldiv·div.tablediv를 추출.
+   각 페이지 <head>에서 <link href="layout/board-layout.css">로 로드한다.
+   ※ #pagelayout이 같은 명시도로 2번 정의됨 — CSS상 나중 정의가 승리하므로
+     아래 순서(margin-left형 → margin:0 auto형)를 절대 바꾸지 말 것(동작 보존).
+   ※ 1번째 #pagelayout의 margin-top: -4%;" 끝 "는 기존 오타(브라우저 무시). 바이트 그대로 보존.
+   ※ mypage-list.css도 #pagelayout을 정의하나 값이 다른 별개 집합 + board 페이지(notice/event)는
+     mypage-list.css를 link하지 않으므로 상호 미로드(충돌 없음).
+   ※ qaList는 분기(alldiv 2속성·#pagelayout 단일+margin-bottom:4%·tablediv th 고유)라 제외(인라인 잔류). */
+#pagelayout {
+	margin-left: 20%;
+	margin-bottom: 3%;
+	margin-top: -4%;"
+}
+div.alldiv {
+	margin: 0 auto;
+	width: 80%;
+	border: 0px solid black;
+}
+div.tablediv {
+	margin: 0 auto;
+	padding-top: 5%;
+	border: 0px solid red;
+	width: 70%;
+	display: block;
+}
+#pagelayout {
+	margin: 0 auto;
+	border: 0px solid yellow;
+	padding-top: 4%;
+	width: 70%;
+	display: block;
+}

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -20,39 +20,10 @@
 <link rel="stylesheet" type="text/css" href="layout/button-col.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <link rel="stylesheet" type="text/css" href="layout/span-container-board.css">
+<link rel="stylesheet" type="text/css" href="layout/board-layout.css">
 <style type="text/css">
 
   
-  #pagelayout {
-    margin-left: 20%; 
-    margin-bottom: 3%;
-    margin-top: -4%;" 
-  }
-  
-  
-
-	div.alldiv{
-		margin: 0 auto;
-		width: 80%;
-		border: 0px solid black;
-
-	}
-	
-	div.tablediv{
-		margin:0 auto;
-		padding-top: 5%;
-		border: 0px solid red;
-		width: 70%;
-		display: block;
-	}
-	
-	#pagelayout{
-		margin:0 auto;
-		border: 0px solid yellow;
-		padding-top: 4%;
-		width: 70%;
-		display: block;
-	}
 
 </style>
 


### PR DESCRIPTION
## 요약
noticeList/eventList의 인라인 `<style>`에 **바이트 동일하게 복붙돼 있던 잔여 레이아웃 규칙 4개**(`#pagelayout` 2회 정의·`div.alldiv`·`div.tablediv`)를 `layout/board-layout.css`로 추출(dedup). CSS 슬라이스 작업 슬라이스11.

## 변경
- **신설** `layout/board-layout.css` — 4규칙 + 출처/교차참조 헤더 주석
- **noticeList.jsp / eventList.jsp** — 4규칙 블록 삭제 + 클러스터 끝(`span-container-board.css` 뒤)에 link 1줄 추가
- **qaList**: 변경 없음 (분기라 제외)

## 동작 보존 (순수 리팩터)
- `#pagelayout` **2회 정의 순서 보존** — 같은 명시도라 나중 정의가 승리하므로 순서 불변 유지
- `margin-top: -4%;"` 끝 `"` **오타 바이트 그대로 보존** (브라우저가 무시하는 잘못된 선언, "정리" 대상 아님)
- 형제 link css 어느 것도 동일 셀렉터 미정의 + `mypage-list.css` 미링크 → 캐스케이드 충돌 없음
- board-layout.css가 클러스터 **마지막 link**이라 이전 inline `<style>` 승자와 동일

## 분기 제외 근거 (qaList)
`div.alldiv` 2속성(border 없음·순서 다름)·`#pagelayout` 단일 정의에 `margin-bottom:4%` 추가·`div.tablediv th{background-color:#DFE8E2}` 고유 규칙 → 한 값이라도 달라 dedup 불가.

## 검증
- ✅ **JspC**: 122 JSP translated+compiled, 0 errors (종료코드 0)
- ✅ **오병합 byte**: 2종 삭제분(공백무시) == `board-layout.css` 본문 ×2 (580==580 바이트 동일)
- ✅ **numstat**: event +1/-29, notice +1/-30, 줄끝 churn 0, qaList 미변경
- ✅ **/code-review high**: 결함 0 (동일성/분기/캐스케이드/순서보존/삭제경계/href/오병합/qaList 미접촉 각도)
- ⏳ **IntelliJ+Tomcat 시각 스모크**(미진행): noticeList/eventList 레이아웃 동일 + qaList 회귀 없음 + `board-layout.css` 200 로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)