### PR TITLE
css: 게시판 목록 noticeList·eventList 빈 <style> 블록 제거

### DIFF
--- a/src/main/webapp/eventboard/eventList.jsp
+++ b/src/main/webapp/eventboard/eventList.jsp
@@ -22,13 +22,6 @@
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <link rel="stylesheet" type="text/css" href="layout/span-container-board.css">
 <link rel="stylesheet" type="text/css" href="layout/board-layout.css">
- <style type="text/css">
-
-  
-
-
-
-</style>
 
 </head>
 

--- a/src/main/webapp/noticeboard/noticeList.jsp
+++ b/src/main/webapp/noticeboard/noticeList.jsp
@@ -21,11 +21,6 @@
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset-board.css">
 <link rel="stylesheet" type="text/css" href="layout/span-container-board.css">
 <link rel="stylesheet" type="text/css" href="layout/board-layout.css">
-<style type="text/css">
-
-  
-
-</style>
 
 </head>
 


### PR DESCRIPTION
## 개요
슬라이스1~11에서 게시판 목록 JSP의 인라인 CSS를 공용 외부 `.css`로 모두 추출(dedup)한 결과, noticeList/eventList의 `<style>` 본문이 완전히 비어(CSS 규칙 0개) 공백만 남았다. 렌더링에 영향이 없는 이 빈 `<style></style>` 블록을 통째로 제거하는 **순수 마크업 위생 정리**다(슬라이스12).

## 변경
- `eventboard/eventList.jsp`: 빈 `<style>` 블록 삭제(-7)
- `noticeboard/noticeList.jsp`: 빈 `<style>` 블록 삭제(-5)
- `board-layout.css` 등 link 클러스터·`</head>`·기타 마크업은 **그대로 유지**(순수 삭제, `+`줄 0)

## 성격
- **동작·시각 변화 0** — 빈 `<style>`은 CSS 규칙이 0개라 렌더링에 영향 없음
- `<style>` 태그를 참조하는 JS(`getElementsByTagName('style')` 등) 부재 확인 → 빈 태그 의존 없음

## 검증
- ✅ JspC: 122 JSP 변환+컴파일, 0 오류
- ✅ `git diff -U0`: `-`줄이 전부 빈 `<style>`/공백/`</style>`뿐, `+`줄 0(순수 삭제)
- ✅ /code-review high: 발견사항 0
- ⬜ IntelliJ+Tomcat 시각 스모크(사용자): 슬라이스11 직후와 레이아웃 완전 동일(변화 0) 회귀 없음 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)