### PR TITLE
css: 휴게소 목록 4종 공통 title/search 레이아웃 외부 .css로 분리

### DIFF
--- a/src/main/webapp/hugesoinfo/hugesolist.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist.jsp
@@ -22,16 +22,8 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/hugeso-list.css">
 <style type="text/css">
-#titlearea{
-			text-align: center;
-			margin-bottom: 40px;
-		}
-		
-		#titlearea hr{
-			margin: 0 auto;
-			width: 10%;
-		}
 
 .icon1 , .icon2{
 	width: 30px;
@@ -84,20 +76,6 @@ tr:hover { /* <tr>의 첫번째,두번째 형제 요소 제외하고 나머지 �
 
 .line2{
 	border-bottom: 3px solid darkgray;
-}
-
-#searcharea{
-	display: flex;
-	justify-content: center;
-	margin-bottom: 80px;
-}
-
-#searcharea input{
-	margin-right: 5px;
-}
-
-#searcharea button{
-	background-color: #618E6E;
 }
 
 	div.span-container span{

--- a/src/main/webapp/hugesoinfo/hugesolist2.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2.jsp
@@ -21,16 +21,8 @@
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/banner.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/hugeso-list.css">
 <style type="text/css">
-#titlearea{
-			text-align: center;
-			margin-bottom: 40px;
-		}
-		
-		#titlearea hr{
-			margin: 0 auto;
-			width: 10%;
-		}
 
 #contentarea{
 	margin-bottom: 80px;
@@ -40,22 +32,6 @@
 	background-color:white;
 	border:white;
 }
-
-#searcharea{
-	display: flex;
-	justify-content: center;
-	margin-bottom: 80px;
-}
-
-#searcharea input{
-	margin-right: 5px;
-}
-
-#searcharea button{
-	background-color: #618E6E;
-}
-
-
 
 	div.span-container span{
 		z-index: 9999;

--- a/src/main/webapp/hugesoinfo/hugesolist2search.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolist2search.jsp
@@ -20,16 +20,8 @@
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/hugeso-list.css">
 <style type="text/css">
-#titlearea{
-			text-align: center;
-			margin-bottom: 40px;
-		}
-		
-		#titlearea hr{
-			margin: 0 auto;
-			width: 10%;
-		}
 
 #contentarea{
 	margin-bottom: 80px;
@@ -38,20 +30,6 @@
 .btn{
 	background-color:white;
 	border:white;
-}
-
-#searcharea{
-	display: flex;
-	justify-content: center;
-	margin-bottom: 80px;
-}
-
-#searcharea input{
-	margin-right: 5px;
-}
-
-#searcharea button{
-	background-color: #618E6E;
 }
 
 </style>

--- a/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
+++ b/src/main/webapp/hugesoinfo/hugesolistsearch.jsp
@@ -21,16 +21,8 @@
 
 <link rel="stylesheet" type="text/css" href="layout/pagination.css">
 <link rel="stylesheet" type="text/css" href="layout/anchor-reset.css">
+<link rel="stylesheet" type="text/css" href="layout/hugeso-list.css">
 <style type="text/css">
-#titlearea{
-			text-align: center;
-			margin-bottom: 40px;
-		}
-		
-		#titlearea hr{
-			margin: 0 auto;
-			width: 10%;
-		}
 
 .icon1 , .icon2{
 	width: 30px;
@@ -89,21 +81,6 @@ table td:last-child {
 .line2{
 	border-bottom: 3px solid darkgray;
 }
-
-#searcharea{
-	display: flex;
-	justify-content: center;
-	margin-bottom: 80px;
-}
-
-#searcharea input{
-	margin-right: 5px;
-}
-
-#searcharea button{
-	background-color: #618E6E;
-}
-
 
 </style>
 </head>

--- a/src/main/webapp/layout/hugeso-list.css
+++ b/src/main/webapp/layout/hugeso-list.css
@@ -1,0 +1,31 @@
+@charset "UTF-8";
+/* 휴게소 목록 4종 공통 title/search 레이아웃(공통).
+   hugesolist/hugesolist2/hugesolistsearch/hugesolist2search의 <style>에
+   바이트 동일하게 복붙돼 있던 두 블록을 추출:
+     블록1(상단) #titlearea·#titlearea hr,
+     블록2(하단) #searcharea·#searcharea input·#searcharea button.
+   각 페이지 <head>에서 <link href="layout/hugeso-list.css">로 로드한다.
+   ※ 원본 인라인 순서(top→bottom) 보존. 사이의 페이지 고유 규칙과 셀렉터 교집합 0이라
+     두 블록을 인접 배치해도 결과 불변.
+   ※ banner.css/pagination.css/anchor-reset.css와 셀렉터 교집합 없음(다른 집합).
+   ※ hugesomap/hugesoaddform/hugesoupdateform은 분기(#titlearea margin-top:100px·#searcharea 상이)라
+     제외(인라인 잔류). */
+#titlearea {
+	text-align: center;
+	margin-bottom: 40px;
+}
+#titlearea hr {
+	margin: 0 auto;
+	width: 10%;
+}
+#searcharea {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 80px;
+}
+#searcharea input {
+	margin-right: 5px;
+}
+#searcharea button {
+	background-color: #618E6E;
+}


### PR DESCRIPTION
## 개요
2단계 리팩터링 CSS 슬라이스 후속(슬라이스13). 휴게소 목록 4종(`hugesolist`/`hugesolist2`/`hugesolistsearch`/`hugesolist2search` = {목록형,앨범형}×{전체,검색} 매트릭스)의 인라인 `<style>`에 **공백무시 바이트 동일**하게 복붙돼 있던 두 블록을 신설 `layout/hugeso-list.css`로 추출(dedup). **동작·시각 변화 0**(추출·이동만).

## 변경
- **신설** `src/main/webapp/layout/hugeso-list.css` — 5규칙(원본 top→bottom 순서 보존)
  - 블록1(상단): `#titlearea` · `#titlearea hr`
  - 블록2(하단): `#searcharea` · `#searcharea input` · `#searcharea button`
- 4종 각 파일: 인라인 두 블록 삭제 + Bootstrap 클러스터 끝(`anchor-reset.css` 뒤)·인라인 `<style>` 앞에 `<link>` 1줄 추가(캐스케이드 보존).

## 분기 제외(인라인 잔류·미변경)
- `hugesomap` — `#titlearea`에 `margin-top:100px`, `#searcharea` 본문 전혀 다름(margin-bottom:20px·align-items·justify-content:right). hr·input·button만 동일하나 부모 규칙이 달라 **블록 단위 비동일** → 제외.
- `hugesoaddform`/`hugesoupdateform` — `#titlearea margin-top:100px`(블록1 비동일)·`#searcharea` 없음 → 제외.
- `#contentarea{margin-bottom:80px;}`(산재 단일 규칙)는 범위 제외(후속 후보).

## 캐스케이드
5규칙 전부 id 기반(0,1,0,0~0,1,0,1) → Bootstrap·Reboot 대비 명시도 우위라 로드순서·info.jsp Bootstrap 재로딩 무관 승자 불변. 형제 외부 css(pagination/banner/anchor-reset)에 동일 셀렉터 0건. 4종 내 재정의 0건.

## 검증
- **오병합 검증**: 4종 삭제분 == `hugeso-list.css` 본문 공백무시 바이트 동일(233바이트).
- `git diff -U0`: `+`줄=link 1줄/파일, `-`줄=블록 규칙/공백뿐. numstat 각 `+1/-23~25`, 줄끝 churn 0. 분기 3종 미변경.
- JspC: `scripts/jspc-check.ps1` EXIT=0(122 JSP).
- /code-review high(캐스케이드·href·제거완전성·동작 보존): 0건.
- ⚠ **IntelliJ+Tomcat 시각 스모크 대기**(CSS 자동 게이트 없음): 4종 목록/검색 화면의 제목영역(가운데·hr 폭 10%)·검색박스(가로 배치·input 간격·버튼 초록 #618E6E)·하단 마진 동일 + 분기 3종 회귀 없음 + 신규 css 200 로드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)